### PR TITLE
Remove auto scaling from screenshots

### DIFF
--- a/applications/addons/js/addon.js
+++ b/applications/addons/js/addon.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function($) {
 
-	$("a[rel^='popable']").fancyZoom({scaleImg: true, closeOnClick: true});
+	$("a[rel^='popable']").fancyZoom({closeOnClick: true});
 
    // Hide comment deletes and hijack their clicks to confirm
    $('a.DeleteComment').popup({


### PR DESCRIPTION
This removes the slight scaling of screenshots (~2%) that causes the browser to interpolate and results in "blurry" screenshots.

I tested this with tiny (10x10), small (100x100), medium (497x304), large (1280x720), and enormous (4288x2585) screenshots. This improves display of medium, large, and enormous screenshots. Tiny and small screenshots are no longer scaled up, which may be desired, but I feel they look bad. Also, tiny and small screenshots are rarely uploaded in my experience.
