### PR TITLE
Update dashboard feed locations

### DIFF
--- a/applications/vforg/controllers/class.homecontroller.php
+++ b/applications/vforg/controllers/class.homecontroller.php
@@ -117,18 +117,12 @@ class HomeController extends VFOrgController {
       $this->MaxLength = is_numeric($Length) && $Length <= 50 ? $Length : 5;
       $this->FeedFormat = $FeedFormat;
       switch ($Type) {
-         case 'news':
-            $Url = 'http://blog.vanillaforums.com/category/dashboardnews/feed/';
-            break;
-         case 'events':
-            $Url = 'http://blog.vanillaforums.com/category/events/feed/';
-            break;
+         case 'releases':
          case 'help':
-            $Url = 'http://blog.vanillaforums.com/category/help/feed/';
-            break;
-         case 'announce':
             $Url = 'http://vanillaforums.org/categories/blog/feed.rss';
             break;
+         case 'news':
+         case 'cloud':
          default:
             $Url = 'http://blog.vanillaforums.com/feed/';
       }

--- a/applications/vforg/views/home/getfeed.php
+++ b/applications/vforg/views/home/getfeed.php
@@ -11,18 +11,20 @@ foreach ($this->Feed->channel->item as $Item) {
    $PubDate = strtotime(GetValue('pubDate', $Item));
    if ($this->FeedFormat == 'extended') {
       $Description = GetValue('description', $Item);
+      // Cut off after the first subheading.
+      $Description = array_shift(explode('<h', $Description));
       echo Wrap(
-         Anchor($Title, $Link)
-         .Wrap(Gdn_Format::Date($PubDate), 'div', array('class' => 'Date'))
-         .Wrap($Description, 'em'),
-         'div',
-         array('class' => 'FeedItem')
+         Wrap(Anchor($Title, $Link), 'h2')
+            .Wrap(Gdn_Format::Date($PubDate), 'div', array('class' => 'Date'))
+            .Wrap($Description, 'div', array('class' => 'FeedDescription')),
+         'div', array('class' => 'FeedItem ExtendedFormat')
       );
    } else {
       echo Wrap(
-         '<i class="Sprite SpriteRarr SpriteRarrDown"><span>&rarr;</span></i>'
-         .Anchor($Title, $Link),
-         'div'
+         '<span class="Sprite SpriteRarr SpriteRarrDown">&rarr;</span>'
+            .Anchor($Title, $Link)
+            .Wrap(Gdn_Format::Date($PubDate), 'div', array('class' => 'Date')),
+         'div', array('class' => 'FeedItem NormalFormat')
       );
    }
    $Loop++;


### PR DESCRIPTION
This should maintain existing feeds in place (only 'news' appears to be called currently) while allowing us to differentiate between OSS & cloud feeds in the future. Also improves the markup, and truncates how much is pulled from the body of a discussion.