### PR TITLE
Feature/assign addon existing discussion

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -572,14 +572,19 @@ class AddonController extends AddonsController {
     }
 
     if ($this->Form->IsPostBack()) {
-      $Model->SetField($ID, 'AddonID', NULL);
-
-      if ($this->DeliveryType() === DELIVERY_TYPE_ALL) {
-        Redirect($RedirectUrl);
-      } else {
-        $this->InformMessage(T('Successfully removed addon Attachment'));
-        $this->JsonTarget('.Warning.AddonAttachment', NULL, 'Remove');
-        $this->JsonTarget('a.AttachAddonDiscussion.Popup', T('Attach to Addon...'), 'Text');
+      
+      if (!$this->Form->GetFormValue('DetachConfirm', FALSE)) {
+        $this->Form->AddError(T('You must confirm the detachment'), 'DetachConfirm');
+      }
+      else {
+        $Model->SetField($ID, 'AddonID', NULL);
+        if ($this->DeliveryType() === DELIVERY_TYPE_ALL) {
+          Redirect($RedirectUrl);
+        } else {
+          $this->InformMessage(T('Successfully detached addon'));
+          $this->JsonTarget('.Warning.AddonAttachment', NULL, 'Remove');
+          $this->JsonTarget('a.AttachAddonDiscussion.Popup', T('Attach Addon...'), 'Text');
+        }
       }
     }
     $this->Render();

--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -500,79 +500,78 @@ class AddonController extends AddonsController {
   }
 
   public function AttachToDiscussion($DiscussionID = NULL) {
-    $this->Permission('Addons.Addon.Manage');
-    $DiscussionModel = new DiscussionModel();
-    $Discussion = $DiscussionModel->GetID($DiscussionID);
-    if ($Discussion) {
-      $Addon = $this->AddonModel->GetID($Discussion->AddonID);
-      $this->Form->SetData($Addon);
-      $RedirectUrl = 'discussion/' . $Discussion->DiscussionID;
-    } else {
-      throw NotFoundException('Discussion');
-    }
-    
-    if ($this->Form->IsPostBack()) {
-      // Look up for an existing addon
-      $FormValues = $this->Form->FormValues();
-      $Addon = FALSE;
-      if (val('Name', $FormValues, FALSE)) {
-        $Addon = $this->AddonModel->GetWhere(array('a.Name' => $FormValues['Name']))->FirstRow(DATASET_TYPE_ARRAY);
-      }
-
-      if ($Addon == FALSE && val('AddonID', $FormValues, FALSE)) {
-        $Addon = $this->AddonModel->GetID($FormValues['AddonID']);
-      }
-
-      if ($Addon == FALSE) {
-        $this->Form->AddError(T('Unable to find addon via Name or ID'));
-      }
-
-      if ($this->Form->ErrorCount() == 0) {
-        $DiscussionModel->SetField($DiscussionID, 'AddonID', $Addon['AddonID']);
-        if ($this->DeliveryType() === DELIVERY_TYPE_ALL) {
-          Redirect($RedirectUrl ? : 'addon/' . $Addon['AddonID']);
+        $this->Permission('Addons.Addon.Manage');
+        $DiscussionModel = new DiscussionModel();
+        $Discussion = $DiscussionModel->GetID($DiscussionID);
+        if ($Discussion) {
+            $Addon = $this->AddonModel->GetID($Discussion->AddonID);
+            $this->Form->SetData($Addon);
+            $RedirectUrl = 'discussion/' . $Discussion->DiscussionID;
         } else {
-          $this->InformMessage(T('Successfully updated Attached Addon!'));
-          $this->JsonTarget('.Warning.AddonAttachment', NULL, 'Remove');
-          $this->JsonTarget('.ItemDiscussion .Message', RenderDiscussionAddonWarning($Addon['AddonID'], $Addon['Name'], $Discussion->DiscussionID), 'Prepend');
-          $this->JsonTarget('a.AttachAddonDiscussion.Popup', T('Edit Addon Attachment...'), 'Text');
+            throw NotFoundException('Discussion');
         }
-      }
+
+        if ($this->Form->AuthenticatedPostBack()) {
+            // Look up for an existing addon
+            $FormValues = $this->Form->FormValues();
+            $Addon = false;
+            if (val('Name', $FormValues, FALSE)) {
+                $Addon = $this->AddonModel->GetWhere(array('a.Name' => $FormValues['Name']))->FirstRow(DATASET_TYPE_ARRAY);
+            }
+
+            if ($Addon == FALSE && val('AddonID', $FormValues, FALSE)) {
+                $Addon = $this->AddonModel->GetID($FormValues['AddonID']);
+            }
+
+            if ($Addon == FALSE) {
+                $this->Form->AddError(T('Unable to find addon via Name or ID'));
+            }
+
+            if ($this->Form->ErrorCount() == 0) {
+                $DiscussionModel->SetField($DiscussionID, 'AddonID', $Addon['AddonID']);
+                if ($this->DeliveryType() === DELIVERY_TYPE_ALL) {
+                    Redirect($RedirectUrl ? : 'addon/' . $Addon['AddonID']);
+                } else {
+                    $this->InformMessage(T('Successfully updated Attached Addon!'));
+                    $this->JsonTarget('.Warning.AddonAttachment', NULL, 'Remove');
+                    $this->JsonTarget('.ItemDiscussion .Message', RenderDiscussionAddonWarning($Addon['AddonID'], $Addon['Name'], $Discussion->DiscussionID), 'Prepend');
+                    $this->JsonTarget('a.AttachAddonDiscussion.Popup', T('Edit Addon Attachment...'), 'Text');
+                }
+            }
+        }
+
+        $this->Render('attach');
     }
 
-    $this->Render('attach');
-  }
-
-  public function DetachFromDiscussion($DiscussionID = NULL) {
-    $this->Permission('Addons.Addon.Manage');
-    $DiscussionModel = new DiscussionModel();
-    $Discussion = $DiscussionModel->GetID($DiscussionID);
-    if ($Discussion) {
-      $Addon = $this->AddonModel->GetID($Discussion->AddonID);
-      $this->Form->SetData($Addon);
-      $RedirectUrl = 'discussion/' . $Discussion->DiscussionID;
-    } else {
-      throw NotFoundException('Discussion');
-    }
-    
-    if ($this->Form->IsPostBack()) {
-      
-      if (!$this->Form->GetFormValue('DetachConfirm', FALSE)) {
-        $this->Form->AddError(T('You must confirm the detachment'), 'DetachConfirm');
-      }
-      else {
-        $DiscussionModel->SetField($DiscussionID, 'AddonID', NULL);
-        if ($this->DeliveryType() === DELIVERY_TYPE_ALL) {
-          Redirect($RedirectUrl);
+    public function DetachFromDiscussion($DiscussionID = NULL) {
+        $this->Permission('Addons.Addon.Manage');
+        $DiscussionModel = new DiscussionModel();
+        $Discussion = $DiscussionModel->GetID($DiscussionID);
+        if ($Discussion) {
+            $Addon = $this->AddonModel->GetID($Discussion->AddonID);
+            $this->Form->SetData($Addon);
+            $RedirectUrl = 'discussion/' . $Discussion->DiscussionID;
         } else {
-          $this->InformMessage(T('Successfully detached addon'));
-          $this->JsonTarget('.Warning.AddonAttachment', NULL, 'Remove');
-          $this->JsonTarget('a.AttachAddonDiscussion.Popup', T('Attach Addon...'), 'Text');
+            throw NotFoundException('Discussion');
         }
-      }
+
+        if ($this->Form->AuthenticatedPostBack()) {
+
+            if (!$this->Form->GetFormValue('DetachConfirm', FALSE)) {
+                $this->Form->AddError(T('You must confirm the detachment'), 'DetachConfirm');
+            } else {
+                $DiscussionModel->SetField($DiscussionID, 'AddonID', NULL);
+                if ($this->DeliveryType() === DELIVERY_TYPE_ALL) {
+                    Redirect($RedirectUrl);
+                } else {
+                    $this->InformMessage(T('Successfully detached addon'));
+                    $this->JsonTarget('.Warning.AddonAttachment', NULL, 'Remove');
+                    $this->JsonTarget('a.AttachAddonDiscussion.Popup', T('Attach Addon...'), 'Text');
+                }
+            }
+        }
+        $this->Render('detach');
     }
-    $this->Render('detach');
-  }
 
   protected static function NotFoundString($Code, $Item) {
       return sprintf(T('%1$s "%2$s" not found.'), T($Code), $Item);

--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -542,7 +542,7 @@ class AddonController extends AddonsController {
         } else {
           $this->InformMessage(T('Successfully updated Attached Addon!'));
           $this->JsonTarget('.Warning.AddonAttachment', NULL, 'Remove');
-          $this->JsonTarget('.Item' . ucfirst($Type) . ' .Message', RenderDiscussionAddonWarning($Addon['AddonID'], $Addon['Name']), 'Prepend');
+          $this->JsonTarget('.Item' . ucfirst($Type) . ' .Message', RenderDiscussionAddonWarning($Addon['AddonID'], $Addon['Name'], $Discussion->DiscussionID), 'Prepend');
           $this->JsonTarget('a.AttachAddonDiscussion.Popup', T('Edit Addon Attachment...'), 'Text');
         }
       }

--- a/applications/addons/library/functions.render.php
+++ b/applications/addons/library/functions.render.php
@@ -1,19 +1,25 @@
 <?php if (!defined('APPLICATION')) exit();
 
 if (!function_exists('RenderDiscussionAddonWarning')) {
-function RenderDiscussionAddonWarning($AddonID, $AddonName, $Placeholder = FALSE) {
-  if($Placeholder) {
-    $String = Wrap(T('This discussion is not related to any addon.'),'div', array('class' => 'Warning AddonAttachment Hidden'));
+function RenderDiscussionAddonWarning($AddonID, $AddonName, $AttachID) {
+  $DeleteOption = '';
+  if (Gdn::Session()->CheckPermission('Addons.Addon.Manage')) {
+    $DeleteOption = Wrap(
+            Anchor(
+                    'x',
+                    'addon/detach/discussion/' . $AttachID,
+                    array('class' => 'Delete')),
+            'div',
+            array('class' => 'Options'));
   }
-  else {
-    $String = Wrap(
-            sprintf(
-                    T('This discussion is related to the %s addon.'), Anchor(
-                            $AddonName, 'addon/' . $AddonID . '/' . Gdn_Format::Url($AddonName)
-                    )
-            ), 'div', array('class' => 'Warning AddonAttachment')
-    );
-  }
-    return $String;
-  }
+  $String = Wrap(
+          sprintf(
+                  T('This discussion is related to the %s addon.'), Anchor(
+                          $AddonName, 'addon/' . $AddonID . '/' . Gdn_Format::Url($AddonName)
+                  )
+          ) .
+          $DeleteOption, 'div', array('class' => 'Warning AddonAttachment')
+  );
+  return $String;
+}
 }

--- a/applications/addons/library/functions.render.php
+++ b/applications/addons/library/functions.render.php
@@ -6,7 +6,7 @@ function RenderDiscussionAddonWarning($AddonID, $AddonName, $AttachID) {
   if (Gdn::Session()->CheckPermission('Addons.Addon.Manage')) {
     $DeleteOption = Anchor(
                     'x',
-                    'addon/detach/discussion/' . $AttachID,
+                    'addon/detachfromdiscussion/' . $AttachID,
                     array('class' => 'Dismiss'));
   }
   $String = Wrap(

--- a/applications/addons/library/functions.render.php
+++ b/applications/addons/library/functions.render.php
@@ -1,0 +1,19 @@
+<?php if (!defined('APPLICATION')) exit();
+
+if (!function_exists('RenderDiscussionAddonWarning')) {
+function RenderDiscussionAddonWarning($AddonID, $AddonName, $Placeholder = FALSE) {
+  if($Placeholder) {
+    $String = Wrap(T('This discussion is not related to any addon.'),'div', array('class' => 'Warning AddonAttachment Hidden'));
+  }
+  else {
+    $String = Wrap(
+            sprintf(
+                    T('This discussion is related to the %s addon.'), Anchor(
+                            $AddonName, 'addon/' . $AddonID . '/' . Gdn_Format::Url($AddonName)
+                    )
+            ), 'div', array('class' => 'Warning AddonAttachment')
+    );
+  }
+    return $String;
+  }
+}

--- a/applications/addons/library/functions.render.php
+++ b/applications/addons/library/functions.render.php
@@ -4,21 +4,18 @@ if (!function_exists('RenderDiscussionAddonWarning')) {
 function RenderDiscussionAddonWarning($AddonID, $AddonName, $AttachID) {
   $DeleteOption = '';
   if (Gdn::Session()->CheckPermission('Addons.Addon.Manage')) {
-    $DeleteOption = Wrap(
-            Anchor(
+    $DeleteOption = Anchor(
                     'x',
                     'addon/detach/discussion/' . $AttachID,
-                    array('class' => 'Delete')),
-            'div',
-            array('class' => 'Options'));
+                    array('class' => 'Dismiss'));
   }
   $String = Wrap(
+          $DeleteOption . 
           sprintf(
                   T('This discussion is related to the %s addon.'), Anchor(
                           $AddonName, 'addon/' . $AddonID . '/' . Gdn_Format::Url($AddonName)
                   )
-          ) .
-          $DeleteOption, 'div', array('class' => 'Warning AddonAttachment')
+          ), 'div', array('class' => 'Warning AddonAttachment DismissMessage')
   );
   return $String;
 }

--- a/applications/addons/settings/bootstrap.php
+++ b/applications/addons/settings/bootstrap.php
@@ -1,0 +1,3 @@
+<?php if (!defined('APPLICATION')) exit();
+
+require_once(PATH_APPLICATIONS . DS . 'addons' . DS . 'library' . DS . 'functions.render.php');

--- a/applications/addons/settings/class.hooks.php
+++ b/applications/addons/settings/class.hooks.php
@@ -81,7 +81,7 @@ class AddonsHooks implements Gdn_IPlugin {
        
        $Sender->EventArguments['DiscussionOptions'][] = array(
            'Label' => $LabelString,
-           'Url' => 'addon/attach/discussion/' . $Discussion->DiscussionID,
+           'Url' => 'addon/attachtodiscussion/' . $Discussion->DiscussionID,
            'Class' => 'AttachAddonDiscussion Popup');
    }
    

--- a/applications/addons/settings/class.hooks.php
+++ b/applications/addons/settings/class.hooks.php
@@ -59,7 +59,7 @@ class AddonsHooks implements Gdn_IPlugin {
       if (GetValue('Type', $Sender->EventArguments) == 'Discussion' && is_numeric($AddonID) && $AddonID > 0) {
          $Data = Gdn::Database()->SQL()->Select('Name')->From('Addon')->Where('AddonID', $AddonID)->Get()->FirstRow();
          if ($Data) {
-            echo '<div class="Warning">'.sprintf(T('This discussion is related to the %s addon.'), Anchor($Data->Name, 'addon/'.$AddonID.'/'.Gdn_Format::Url($Data->Name))).'</div>';
+            echo RenderDiscussionAddonWarning($AddonID, $Data->Name);
          }
       }
    }

--- a/applications/addons/settings/class.hooks.php
+++ b/applications/addons/settings/class.hooks.php
@@ -76,7 +76,7 @@ class AddonsHooks implements Gdn_IPlugin {
        $Discussion = $Sender->EventArguments['Discussion'];
        $LabelString = T('Edit Addon Attachment...');
        if(is_null($Discussion->AddonID)) {
-           $LabelString = T('Attach to Addon...');
+           $LabelString = T('Attach Addon...');
        }
        
        $Sender->EventArguments['DiscussionOptions'][] = array(

--- a/applications/addons/settings/class.hooks.php
+++ b/applications/addons/settings/class.hooks.php
@@ -59,7 +59,7 @@ class AddonsHooks implements Gdn_IPlugin {
       if (GetValue('Type', $Sender->EventArguments) == 'Discussion' && is_numeric($AddonID) && $AddonID > 0) {
          $Data = Gdn::Database()->SQL()->Select('Name')->From('Addon')->Where('AddonID', $AddonID)->Get()->FirstRow();
          if ($Data) {
-            echo RenderDiscussionAddonWarning($AddonID, $Data->Name);
+            echo RenderDiscussionAddonWarning($AddonID, $Data->Name, val('DiscussionID', $Discussion));
          }
       }
    }

--- a/applications/addons/settings/class.hooks.php
+++ b/applications/addons/settings/class.hooks.php
@@ -72,6 +72,19 @@ class AddonsHooks implements Gdn_IPlugin {
       AddonModel::JoinAddons($Args['Data'], 'AddonID', array('Name', 'Icon', 'AddonKey', 'AddonTypeID', 'Checked'));
    }
    
+   public function Base_DiscussionOptions_Handler($Sender) {
+       $Discussion = $Sender->EventArguments['Discussion'];
+       $LabelString = T('Edit Addon Attachment...');
+       if(is_null($Discussion->AddonID)) {
+           $LabelString = T('Attach to Addon...');
+       }
+       
+       $Sender->EventArguments['DiscussionOptions'][] = array(
+           'Label' => $LabelString,
+           'Url' => 'addon/attach/discussion/' . $Discussion->DiscussionID,
+           'Class' => 'AttachAddonDiscussion Popup');
+   }
+   
    public function DiscussionsController_BeforeDiscussionContent_Handler($Sender, $Args) {
       static $AddonModel = NULL;
       if (!$AddonModel) $AddonModel = new AddonModel();

--- a/applications/addons/views/addon/attach.php
+++ b/applications/addons/views/addon/attach.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) exit();
-echo Wrap(T('Edit Attached Addon'), 'h2');
+echo Wrap(T('Edit Addon Attachment'), 'h2');
 
 echo $this->Form->Open();
 echo $this->Form->Errors();

--- a/applications/addons/views/addon/attach.php
+++ b/applications/addons/views/addon/attach.php
@@ -1,0 +1,27 @@
+<?php if (!defined('APPLICATION')) exit();
+echo Wrap(T('Edit Attached Addon'), 'h2');
+
+echo $this->Form->Open();
+echo $this->Form->Errors();
+?>
+<ul>
+    <li>
+        <?php
+        echo $this->Form->Label('Addon Name', 'Name');
+        echo $this->Form->TextBox('Name');
+        ?>
+    </li>
+    <li>
+        <?php
+        echo $this->Form->Label('Addon ID', 'AddonID');
+        echo $this->Form->TextBox('AddonID');
+        ?>
+    </li>
+    <li>
+        <?php
+        echo $this->Form->CheckBox('RemoveAttachment', 'Remove the addon attachment?');
+        ?>
+    </li>
+</ul>
+<?php
+echo $this->Form->Close('Save');

--- a/applications/addons/views/addon/attach.php
+++ b/applications/addons/views/addon/attach.php
@@ -17,11 +17,6 @@ echo $this->Form->Errors();
         echo $this->Form->TextBox('AddonID');
         ?>
     </li>
-    <li>
-        <?php
-        echo $this->Form->CheckBox('RemoveAttachment', 'Remove the addon attachment?');
-        ?>
-    </li>
 </ul>
 <?php
 echo $this->Form->Close('Save');

--- a/applications/addons/views/addon/detach.php
+++ b/applications/addons/views/addon/detach.php
@@ -1,0 +1,15 @@
+<?php if (!defined('APPLICATION')) exit();
+echo Wrap(T('Detach Addon from Discussion'), 'h2');
+
+echo $this->Form->Open();
+echo $this->Form->Errors();
+?>
+<ul>
+    <li>
+        <?php
+        echo $this->Form->CheckBox('DetachConfirm', 'Are you sure you want to remove the addon attachment?');
+        ?>
+    </li>
+</ul>
+<?php
+echo $this->Form->Close('Detach');


### PR DESCRIPTION
This allows users with the 'Addons.Addon.Manage' permission to attach/detach addons from the discussion options menu.

I would like some feedback:

1. Is this the appropriate permission to check?
2. Should I make the detach action occur in a popup?
3. Should the attach/detach methods be re-located to the hooks file and extend the discussion controller?