### PR TITLE
Update definition to use the `href` attribute and point to current docs.

### DIFF
--- a/applications/addons/locale/en-CA/definitions.php
+++ b/applications/addons/locale/en-CA/definitions.php
@@ -14,4 +14,4 @@ $Definition['ValidateAddonKey'] = 'The addon key cannot be a number and cannot c
 $Definition['AddonHelpForApplication'] = 'This addon is a <b>application</b>. You need to extract it to your <code>/applications</code> folder to install it.';
 $Definition['AddonHelpForPlugin'] = 'This addon is a <b>plugin</b>. You need to extract it to your <code>/plugins</code> folder to install it.';
 $Definition['AddonHelpForTheme'] = 'This addon is a <b>theme</b>. You need to extract it to your <code>/themes</code> folder to install it.';
-$Definition['AddonHelpForLocale'] = 'This addon is a <b>locale</b>. You need to extract it to your <code>/locales</code> folder to install it. For more help with locales check out the help topic <a hreg="http://vanillaforums.org/page/Localization">here</a>.';
+$Definition['AddonHelpForLocale'] = 'This addon is a <b>locale</b>. You need to extract it to your <code>/locales</code> folder to install it. For more help with locales check out the help topic <a href="//docs.vanillaforums.com/developers/locales/">here</a>.';


### PR DESCRIPTION
This moves the locale documentation link to the `href` attribute and also updates the URL to the current docs.