### PR TITLE
Fix incorrect keyword path

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -771,7 +771,7 @@ class AddonController extends AddonsController {
             $Offset,
             $Limit,
             $NumResults,
-            'addon/browse/'.$FilterToType.'/'.$Sort.'/'.$this->Version.'/%1$s/?Form/Keywords='.urlencode($Search)
+            'addon/browse/'.$FilterToType.'/'.$Sort.'/'.$this->Version.'/%1$s/?Keywords='.urlencode($Search)
         );
         $this->SetData('_Pager', $Pager);
 


### PR DESCRIPTION
From the forums: http://vanillaforums.org/discussion/30184/vanillaforums-org-addons-search-bug

This corrects the GET term to the expected name in the controller.