### PR TITLE
Add community confidence rating to addons

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -111,7 +111,7 @@ class AddonController extends AddonsController {
          
         $this->Form->AddHidden('AddonVersionID', $addon['CurrentAddonVersionID']);
         $this->Form->AddHidden('UserID', $session->UserID);
-        $this->Form->AddHidden('CoreVersionID', $this->ConfidenceModel->getCoreVersion());            
+        $this->Form->AddHidden('CoreVersionID', $this->ConfidenceModel->getCoreVersion()->AddonVersionID);            
 
         
         $existingConfidenceRecord = $this->ConfidenceModel->getCurrentConfidence($session->UserID, $addon['CurrentAddonVersionID']);

--- a/applications/addons/models/class.confidencemodel.php
+++ b/applications/addons/models/class.confidencemodel.php
@@ -1,0 +1,60 @@
+<?php
+class ConfidenceModel extends Gdn_Model {
+
+    public function __construct($Name = '') {
+        parent::__construct('Confidence');
+    }
+    
+    public function getCoreVersions($Limit = 5) {
+        return $this->SQL->Select('a.AddonID, a.Name, av.AddonVersionID, av.Version')
+                ->From('Addon a')
+                ->Where('a.AddonTypeID', ADDON_TYPE_CORE)
+                ->Where('a.AddonKey', 'vanilla')
+                ->Join('AddonVersion av', 'a.AddonID = av.AddonID')
+                ->OrderBy('av.DateInserted', 'desc')
+                ->Limit($Limit)
+                ->Get()
+                ->Result();
+    }
+
+    public function getCoreVersion() {
+        return $this->SQL->Select('av.AddonVersionID')
+                ->From('Addon a')
+                ->Where('a.AddonTypeID', ADDON_TYPE_CORE)
+                ->Where('a.AddonKey', 'vanilla')
+                ->Join('AddonVersion av', 'a.AddonID = av.AddonID')
+                ->OrderBy('av.DateInserted', 'desc')
+                ->Limit(1)
+                ->Get()
+                ->FirstRow()
+                ->AddonVersionID;
+    }
+    
+    public function getID($AddonVersionID, $DataType = DATASET_TYPE_ARRAY) {
+        $CoreVersion = $this->getCoreVersion();
+        $Confidence = $this->SQL
+                ->Select('c.AddonVersionID, c.CoreVersionID, av.Version as CoreVersion, COUNT(c.ConfidenceID) as TotalVotes, SUM(c.Weight) as TotalWeight, AVG(c.Weight) as AverageWeight')
+                ->From('Confidence c')
+                ->Where('c.AddonVersionID', $AddonVersionID)
+                ->Where('c.CoreVersionID', $CoreVersion)
+                ->Join('AddonVersion av', 'c.CoreVersionID = av.AddonVersionID')
+                ->GroupBy('c.AddonVersionID')
+                ->Get()
+                ->FirstRow($DataType);
+        
+        return $Confidence;
+    }
+    
+    public function getCurrentConfidence($userID, $addonID) {
+        $CoreVersion = $this->getCoreVersion();
+        return $this->SQL
+                ->Select('c.*')
+                ->From('Confidence c')
+                ->Where('c.AddonVersionID', $addonID)
+                ->Where('c.CoreVersionID', $CoreVersion)
+                ->Where('c.UserID', $userID)
+                ->Get()
+                ->FirstRow();
+    }
+
+}

--- a/applications/addons/settings/structure.php
+++ b/applications/addons/settings/structure.php
@@ -98,12 +98,12 @@ $Construct->Table('AddonPicture')
     ->Column('DateInserted', 'datetime')
     ->Set($Explicit, $Drop);
 
-$Construct->Table('AddonConfidence')
-   ->PrimaryKey('AddonConfidenceID')
+$Construct->Table('Confidence')
+   ->PrimaryKey('ConfidenceID')
    ->Column('AddonVersionID', 'int', FALSE, 'key')
    ->Column('CoreVersionID', 'int', FALSE, 'key')
    ->Column('UserID', 'int', FALSE, 'key')
-   ->Column('Confidence', 'int', NULL)
+   ->Column('Weight', 'int', NULL)
    ->Set($Explicit, $Drop);
 
 $Construct->Table('Download')

--- a/applications/addons/settings/structure.php
+++ b/applications/addons/settings/structure.php
@@ -98,6 +98,14 @@ $Construct->Table('AddonPicture')
     ->Column('DateInserted', 'datetime')
     ->Set($Explicit, $Drop);
 
+$Construct->Table('AddonConfidence')
+   ->PrimaryKey('AddonConfidenceID')
+   ->Column('AddonVersionID', 'int', FALSE, 'key')
+   ->Column('CoreVersionID', 'int', FALSE, 'key')
+   ->Column('UserID', 'int', FALSE, 'key')
+   ->Column('Confidence', 'int', NULL)
+   ->Set($Explicit, $Drop);
+
 $Construct->Table('Download')
     ->PrimaryKey('DownloadID')
     ->Column('AddonID', 'int', FALSE, 'key')

--- a/applications/addons/views/addon/addon.php
+++ b/applications/addons/views/addon/addon.php
@@ -1,229 +1,132 @@
 <?php if (!defined('APPLICATION')) exit();
+include($this->FetchViewLocation('helper_functions'));
 $Session = Gdn::Session();
-$VanillaVersion = $this->Data('Vanilla2') == '1' ? '2' : '1';
-
 ?><div itemscope itemtype="http://schema.org/SoftwareApplication"><?php
+    echo '<link itemprop="url" href="' . htmlspecialchars(Gdn::Controller()->CanonicalUrl()) . '" />';
 
-echo '<link itemprop="url" href="'.htmlspecialchars(Gdn::Controller()->CanonicalUrl()).'" />';
-
-if ($this->DeliveryType() == DELIVERY_TYPE_ALL) {
-    // echo $this->FetchView('head');
-    ?>
-    <h1>
-        <div>
-            <?php echo T('Found in: ');
-            echo Anchor('Addons', '/addon/browse/');
-            ?>
-            <span>&rarr;</span> <?php
+    if ($this->DeliveryType() == DELIVERY_TYPE_ALL) {
+        // echo $this->FetchView('head');
+        ?>
+        <h1>
+            <div>
+                <?php
+                echo T('Found in: ');
+                echo Anchor('Addons', '/addon/browse/');
+                ?>
+                <span>&rarr;</span> <?php
                 $TypesPlural = array_flip($this->Data('_TypesPlural'));
                 $TypePlural = GetValue($this->Data('AddonTypeID'), $TypesPlural, 'all');
-                echo Anchor(T($TypePlural), '/addon/browse/'.strtolower($TypePlural), '', array('itemprop' => 'softwareApplicationCategory'));
-            ?>
-        </div>
-        <span itemprop="name"><?php echo $this->Data('Name'); ?></span>
-        <span itemprop="softwareVersion"><?php echo $this->Data('Version'); ?></span>
-    </h1>
-    <?php
-    $AddonID = $this->Data('AddonID');
-    $AddonVersionID = $this->Data('AddonVersionID');
-    $Ver = ($this->Data('Checked') ? '' : 'v1');
-    $Ver2 = ($this->Data('Checked') || $this->Data('Vanilla2') ? '' : 'v1');
-    if ($Session->UserID == $this->Data('InsertUserID') || $Session->CheckPermission('Addons.Addon.Manage')) {
-        echo '<div class="AddonOptions">';
-        echo Anchor('Edit Details', "/addon/edit{$Ver}/$AddonID", 'Popup');
-        echo '|'.Anchor('Upload New Version', "/addon/newversion{$Ver2}/$AddonID");
-        echo '|'.Anchor('Upload Screen', '/addon/addpicture/'.$AddonID);
-        echo '|'.Anchor('Upload Icon', '/addon/icon/'.$AddonID);
-        if ($Session->CheckPermission('Addons.Addon.Manage'))
-            echo '|'.Anchor('Check', '/addon/check/'.$AddonID);
-        if ($Session->CheckPermission('Addons.Addon.Manage'))
-            echo '|'.Anchor($this->Data('DateReviewed') == '' ? 'Approve Version' : 'Unapprove Version', '/addon/approve?addonversionid='.$AddonVersionID, 'ApproveAddon');
-        if ($Session->CheckPermission('Addons.Addon.Manage'))
-            echo '|'.Anchor('Delete Addon', '/addon/delete/'.$AddonID.'?Target=/addon', 'DeleteAddon');
-
-        $this->FireEvent('AddonOptions');
-
-        echo '</div>';
-    }
-    if ($this->Data('DateReviewed') == '')
-        echo '<div class="Warning"><strong>Warning!</strong> This community-contributed addon has not been tested or code-reviewed. Use at your own risk.</div>';
-    else
-        echo '<div class="Approved"><strong>Approved!</strong> This addon has been reviewed and approved by Vanilla Forums staff.</div>';
-
-    ?>
-    <div class="Legal">
-        <div class="DownloadPanel">
-            <div class="Box DownloadBox">
-                <p><?php echo Anchor('Download Now', '/get/'.($this->Data('Slug') ? urlencode($this->Data('Slug')) : $AddonID), 'Button BigButton', array('itemprop' => 'downloadURL')); ?></p>
-                <dl>
-                    <dt>Author</dt>
-                    <dd><?php echo UserAnchor($this->Data, NULL, array('Px' => 'Insert', 'Rel' => 'author')); ?></dd>
-                    <dt>Version</dt>
-                    <dd><?php
-                        echo $this->Data('Version');
-
-                        $CurrentVersion = $this->Data('CurrentVersion');
-                        if ($CurrentVersion && $CurrentVersion != $this->Data('Version')) {
-                            echo ' ', Anchor('('.T('Current').')', '/addon/'.AddonModel::Slug($this->Data, FALSE));
-                        }
-                        echo '&#160;';
-
-                    ?></dd>
-                    <dt>Released</dt>
-                    <dd itemprop="datePublished"><?php echo Gdn_Format::Date($this->Data('DateUploaded'), 'html'); ?></dd>
-                    <dt>Downloads</dt>
-                    <dd><meta itemprop="interactionCount" content=”UserDownloads:<?php echo $this->Data('CountDownloads'); ?>" /><?php echo number_format($this->Data('CountDownloads')); ?></dd>
-                    <?php
-                    if ($this->Data('FileSize'))
-                        echo '<dt>File Size</dt><dd>'.'<meta itemprop="fileSize" content="'.$this->Data('FileSize').'"/>'.Gdn_Upload::FormatFileSize($this->Data('FileSize')).'</dd>';
-                    if (Gdn::Session()->CheckPermission('Addons.Addon.Manage')) {
-                        echo '<dt>Checked</dt><dd>'.($this->Data('Checked') ? 'Yes' : 'No').'</dd>';
-                    }
-                    $this->FireEvent('AddonProperties');
-                    ?>
-                </dl>
+                echo Anchor(T($TypePlural), '/addon/browse/' . strtolower($TypePlural), '', array('itemprop' => 'softwareApplicationCategory'));
+                ?>
             </div>
-            <div class="Box RequirementBox">
-                <h3><?php echo T('Requirements'); ?></h3>
-                <div>
-                <dl>
-                    <dt>Vanilla</dt>
-                    <dd><span class="Vanilla<?php echo $VanillaVersion; ?>">Vanilla <?php echo $VanillaVersion; ?></span></dd>
-                </dl>
+            <span itemprop="name"><?php echo $this->Data('Name'); ?></span>
+            <span itemprop="softwareVersion"><?php echo $this->Data('Version'); ?></span>
+        </h1>
+        <?php
+        $AddonID = $this->Data('AddonID');
+        $AddonVersionID = $this->Data('AddonVersionID');
+        $Ver = ($this->Data('Checked') ? '' : 'v1');
+        $Ver2 = ($this->Data('Checked') || $this->Data('Vanilla2') ? '' : 'v1');
+        if ($Session->UserID == $this->Data('InsertUserID') || $Session->CheckPermission('Addons.Addon.Manage')) {
+            echo '<div class="AddonOptions">';
+            echo Anchor('Edit Details', "/addon/edit{$Ver}/$AddonID", 'Popup');
+            echo '|' . Anchor('Upload New Version', "/addon/newversion{$Ver2}/$AddonID");
+            echo '|' . Anchor('Upload Screen', '/addon/addpicture/' . $AddonID);
+            echo '|' . Anchor('Upload Icon', '/addon/icon/' . $AddonID);
+            if ($Session->CheckPermission('Addons.Addon.Manage'))
+                echo '|' . Anchor('Check', '/addon/check/' . $AddonID);
+            if ($Session->CheckPermission('Addons.Addon.Manage'))
+                echo '|' . Anchor($this->Data('DateReviewed') == '' ? 'Approve Version' : 'Unapprove Version', '/addon/approve?addonversionid=' . $AddonVersionID, 'ApproveAddon');
+            if ($Session->CheckPermission('Addons.Addon.Manage'))
+                echo '|' . Anchor('Delete Addon', '/addon/delete/' . $AddonID . '?Target=/addon', 'DeleteAddon');
+
+            $this->FireEvent('AddonOptions');
+
+            echo '</div>';
+        }
+        if ($this->Data('DateReviewed') == '')
+            echo '<div class="Warning"><strong>Warning!</strong> This community-contributed addon has not been tested or code-reviewed. Use at your own risk.</div>';
+        else
+            echo '<div class="Approved"><strong>Approved!</strong> This addon has been reviewed and approved by Vanilla Forums staff.</div>';
+        ?>
+        <div class="Legal">
+            <div class="DownloadPanel">
                 <?php
-                if (!$this->Data('Checked')) {
-                    $OtherRequirements = Gdn_Format::Display($this->Data('Requirements'));
-                    if ($OtherRequirements) {
-                        ?>
-                        <p>Other Requirements:</p>
-                        <?php
-                        echo $OtherRequirements;
-                    }
+                writeDownloadBox($this);
+                writeRequirementBox($this);
+                writeVersionBox($this);
+                writeConfidenceBox($this);
+
+                if ($Session->IsValid()) {
+                    echo Anchor('Ask a Question', 'post/discussion?AddonID=' . $AddonID, 'BigButton');
                 } else {
-                    if (is_array($this->Data('Requirements'))) {
-                        $Reqs = '';
-                        foreach ($this->Data('Requirements') as $ReqType => $ReqItems) {
-                            if (!is_array($ReqItems) || count($ReqItems) == 0)
-                                continue;
-                            $Reqs .= '<dt>'.T($ReqType).'</dt>';
-                            $Reqs .= '<dd>'.htmlspecialchars(ImplodeAssoc(' ', ', ', $ReqItems)).'</dd>';
-                        }
-                        if ($Reqs)
-                            echo "<dl>$Reqs</dl>";
-                    } else {
-                        $OtherRequirements = Gdn_Format::Html($this->Data('Requirements'));
-                        if ($OtherRequirements) {
-                            echo $OtherRequirements;
-                        }
-                    }
+                    echo Anchor('Sign In', '/entry/?Target=' . urlencode($this->SelfUrl), 'BigButton' . (SignInPopup() ? ' SignInPopup' : ''));
                 }
                 ?>
-                </div>
             </div>
             <?php
-            $Versions = (array)$this->Data('Versions');
-            if (count($Versions) > 0):
-            ?>
-            <div class="Box AddonBox VersionsBox">
-                <h3><?php echo T('Latest Versions'); ?></h3>
-                <table class="VersionsTable">
-                    <tr>
-                        <th><?php echo T('Version'); ?></th>
-                        <th class="DateColumn"><?php echo T('Released'); ?></th>
-                    </tr>
-                <?php
-                $i = 1;
-                foreach ($Versions as $Version) {
-                    if ($i > 5)
-                        break;
-                    $i++;
-
-                    $Url = Url('/addon/'.AddonModel::Slug($this->Data, FALSE).'-'.$Version['Version']);
-
-                    echo '<tr>'.
-                        '<td>'.Anchor(htmlspecialchars($Version['Version']), $Url).'</td>'.
-                        '<td class="DateColumn">'.Anchor(htmlspecialchars(Gdn_Format::Date($Version['DateInserted'])), $Url).'</td>'.
-                    '</tr>';
-                }
-                ?>
-                </table>
-            </div>
-            <?php endif; ?>
-
-            <?php
-            if ($Session->IsValid()) {
-                echo Anchor('Ask a Question', 'post/discussion?AddonID='.$AddonID, 'BigButton');
-            } else {
-                echo Anchor('Sign In', '/entry/?Target='.urlencode($this->SelfUrl), 'BigButton'.(SignInPopup() ? ' SignInPopup' : ''));
+            $AddonType = ucfirst($this->Data('Type'));
+            if ($AddonType && $AddonType != 'Core') {
+                $TypeHelp = T('AddonHelpFor' . $AddonType, '');
+                if ($TypeHelp)
+                    echo '<div class="Help">' . $TypeHelp . '</div>';
             }
 
+            if ($this->Data('Icon') != '') {
+                echo '<img class="Icon" src="' . Gdn_Upload::Url($this->Data('Icon')) . '" itemprop="image" />';
+            }
+
+            $CurrentVersion = $this->Data('CurrentVersion');
+            if ($CurrentVersion && $CurrentVersion != $this->Data('Version')) {
+                echo '<p>', sprintf(T("This is not the most recent version of this plugin.", 'This is not the most recent version of this plugin. For the most recent version click <a href="%s">here</a>.'), URL('addon/' . AddonModel::Slug($this->Data, FALSE))), '</p>';
+            }
+
+            echo '<div itemprop="description">';
+
+            echo Gdn_Format::Html($this->Data('Description'));
+            if ($this->Data('Description2') && $Ver != 'v1') {
+                echo '<br /><br />', Gdn_Format::Html($this->Data('Description2'));
+            }
+
+            echo '</div>';
             ?>
         </div>
-    <?php
-
-    $AddonType = ucfirst($this->Data('Type'));
-    if ($AddonType && $AddonType != 'Core') {
-        $TypeHelp = T('AddonHelpFor'.$AddonType, '');
-        if ($TypeHelp)
-            echo '<div class="Help">'.$TypeHelp.'</div>';
-    }
-
-    if ($this->Data('Icon') != '') {
-        echo '<img class="Icon" src="'.Gdn_Upload::Url($this->Data('Icon')).'" itemprop="image" />';
-    }
-
-    $CurrentVersion = $this->Data('CurrentVersion');
-    if ($CurrentVersion && $CurrentVersion != $this->Data('Version')) {
-        echo '<p>', sprintf(T("This is not the most recent version of this plugin.", 'This is not the most recent version of this plugin. For the most recent version click <a href="%s">here</a>.'), URL('addon/'.AddonModel::Slug($this->Data, FALSE))), '</p>';
-    }
-
-    echo '<div itemprop="description">';
-
-    echo Gdn_Format::Html($this->Data('Description'));
-    if ($this->Data('Description2') && $Ver != 'v1') {
-        echo '<br /><br />', Gdn_Format::Html($this->Data('Description2'));
-    }
-
-    echo '</div>';
-
-    ?>
-    </div>
-    <?php
-    if ($this->PictureData->NumRows() > 0) {
-        ?>
-        <div class="PictureBox">
+            <?php
+            if ($this->PictureData->NumRows() > 0) {
+                ?>
+            <div class="PictureBox">
             <?php
             foreach ($this->PictureData->Result() as $Picture) {
                 echo '<span class="AddonPicture">';
-                echo '<a rel="popable[gallery]" href="#Pic_'.$Picture->AddonPictureID.'"><img src="'.Gdn_Upload::Url(ChangeBasename($Picture->File, 'at%s')).'" itemprop="screenshot" /></a>';
+                echo '<a rel="popable[gallery]" href="#Pic_' . $Picture->AddonPictureID . '"><img src="' . Gdn_Upload::Url(ChangeBasename($Picture->File, 'at%s')) . '" itemprop="screenshot" /></a>';
 
                 if ($Session->UserID == $this->Data('InsertUserID') || $Session->CheckPermission('Addons.Addon.Manage')) {
-                    echo '<a class="Popup DeletePicture" href="'.Url('/addon/deletepicture/'.$Picture->AddonPictureID).'">x</a>';
+                    echo '<a class="Popup DeletePicture" href="' . Url('/addon/deletepicture/' . $Picture->AddonPictureID) . '">x</a>';
                 }
 
-                echo '<div id="Pic_'.$Picture->AddonPictureID.'" style="display: none;"><img src="'.Gdn_Upload::Url(ChangeBasename($Picture->File, 'ao%s')).'" /></div>';
+                echo '<div id="Pic_' . $Picture->AddonPictureID . '" style="display: none;"><img src="' . Gdn_Upload::Url(ChangeBasename($Picture->File, 'ao%s')) . '" /></div>';
 
                 echo '</span>';
             }
             ?>
-        </div>
-        <?php
+            </div>
+                <?php
+            }
+            ?>
+        <h2 class="Questions" style="position:relative;">Questions</h2>
+        <?php if (is_object($this->DiscussionData) && $this->DiscussionData->NumRows() > 0) { ?>
+            <ul class="DataList Discussions">
+            <?php
+            $this->ShowOptions = FALSE;
+            include($this->FetchViewLocation('discussions', 'DiscussionsController', 'vanilla'));
+            ?>
+            </ul>
+                <?php
+            } else {
+                ?>
+            <div class="Empty"><?php echo T('No questions yet.'); ?></div>
+            <?php
+        }
     }
     ?>
-    <h2 class="Questions" style="position:relative;">Questions</h2>
-    <?php if (is_object($this->DiscussionData) && $this->DiscussionData->NumRows() > 0) { ?>
-    <ul class="DataList Discussions">
-        <?php
-        $this->ShowOptions = FALSE;
-        include($this->FetchViewLocation('discussions', 'DiscussionsController', 'vanilla'));
-        ?>
-    </ul>
-    <?php
-    } else {
-        ?>
-        <div class="Empty"><?php echo T('No questions yet.'); ?></div>
-        <?php
-    }
-}
-?>
 </div>

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -54,3 +54,116 @@ function WriteAddon($Addon, $Alt) {
     </li>
 <?php
 }
+
+function writeDownloadBox($sender) {
+    ?>
+     <div class="Box DownloadBox">
+     <p><?php echo Anchor('Download Now', '/get/' . ($sender->Data('Slug') ? urlencode($sender->Data('Slug')) : $AddonID), 'Button BigButton', array('itemprop' => 'downloadURL')); ?></p>
+     <dl>
+         <dt>Author</dt>
+         <dd><?php echo UserAnchor($sender->Data, NULL, array('Px' => 'Insert', 'Rel' => 'author')); ?></dd>
+         <dt>Version</dt>
+         <dd><?php
+    echo $sender->Data('Version');
+
+    $CurrentVersion = $sender->Data('CurrentVersion');
+    if ($CurrentVersion && $CurrentVersion != $sender->Data('Version')) {
+        echo ' ', Anchor('(' . T('Current') . ')', '/addon/' . AddonModel::Slug($sender->Data, FALSE));
+    }
+    echo '&#160;';
+    ?></dd>
+         <dt>Released</dt>
+         <dd itemprop="datePublished"><?php echo Gdn_Format::Date($sender->Data('DateUploaded'), 'html'); ?></dd>
+         <dt>Downloads</dt>
+         <dd><meta itemprop="interactionCount" content="UserDownloads: <?php echo $sender->Data('CountDownloads'); ?>" /><?php echo number_format($sender->Data('CountDownloads')); ?></dd>
+    <?php
+    if ($sender->Data('FileSize'))
+        echo '<dt>File Size</dt><dd>' . '<meta itemprop="fileSize" content="' . $sender->Data('FileSize') . '"/>' . Gdn_Upload::FormatFileSize($sender->Data('FileSize')) . '</dd>';
+    if (Gdn::Session()->CheckPermission('Addons.Addon.Manage')) {
+        echo '<dt>Checked</dt><dd>' . ($sender->Data('Checked') ? 'Yes' : 'No') . '</dd>';
+    }
+    $sender->FireEvent('AddonProperties');
+    ?>
+     </dl>
+ </div>
+    <?php
+}
+
+function writeRequirementBox($sender) {
+    $VanillaVersion = $sender->Data('Vanilla2') == '1' ? '2' : '1';
+       ?>
+        <div class="Box RequirementBox">
+                <h3><?php echo T('Requirements'); ?></h3>
+                <div>
+    				<dl>
+    					<dt>Vanilla</dt>
+    					<dd><span class="Vanilla<?php echo $VanillaVersion; ?>">Vanilla <?php echo $VanillaVersion; ?></span></dd>
+    				</dl>
+       <?php
+       if (!$sender->Data('Checked')) {
+           $OtherRequirements = Gdn_Format::Display($sender->Data('Requirements'));
+           if ($OtherRequirements) {
+               ?>
+                              <p>Other Requirements:</p>
+               <?php
+               echo $OtherRequirements;
+           }
+       } else {
+           if (is_array($sender->Data('Requirements'))) {
+               $Reqs = '';
+               foreach ($sender->Data('Requirements') as $ReqType => $ReqItems) {
+                   if (!is_array($ReqItems) || count($ReqItems) == 0)
+                       continue;
+                   $Reqs .= '<dt>' . T($ReqType) . '</dt>';
+                   $Reqs .= '<dd>' . htmlspecialchars(ImplodeAssoc(' ', ', ', $ReqItems)) . '</dd>';
+               }
+               if ($Reqs)
+                   echo "<dl>$Reqs</dl>";
+           } else {
+               $OtherRequirements = Gdn_Format::Html($sender->Data('Requirements'));
+               if ($OtherRequirements) {
+                   echo $OtherRequirements;
+               }
+           }
+       }
+       ?>
+                </div>
+    		</div>
+    <?php
+}
+
+function writeVersionBox($sender) {
+    $Versions = (array) $sender->Data('Versions');
+    if (count($Versions) > 0):
+        ?>
+                 <div class="Box AddonBox VersionsBox">
+                    <h3><?php echo T('Latest Versions'); ?></h3>
+                    <table class="VersionsTable">
+                       <tr>
+                          <th><?php echo T('Version'); ?></th>
+                          <th class="DateColumn"><?php echo T('Released'); ?></th>
+                       </tr>
+        <?php
+        $i = 1;
+        foreach ($Versions as $Version) {
+            if ($i > 5)
+                break;
+            $i++;
+
+            $Url = Url('/addon/' . AddonModel::Slug($sender->Data, FALSE) . '-' . $Version['Version']);
+
+            echo '<tr>' .
+            '<td>' . Anchor(htmlspecialchars($Version['Version']), $Url) . '</td>' .
+            '<td class="DateColumn">' . Anchor(htmlspecialchars(Gdn_Format::Date($Version['DateInserted'])), $Url) . '</td>' .
+            '</tr>';
+        }
+        ?>
+                    </table>
+                 </div>
+    <?php
+    endif;
+}
+
+function writeConfidenceBox($sender) {
+    return;
+}

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -166,23 +166,32 @@ function writeVersionBox($sender) {
 
 function writeConfidenceBox($sender) {
     $confidence = $sender->ConfidenceModel->getID($sender->Data('Versions')[0]['AddonVersionID'], DATASET_TYPE_OBJECT);
+    $coreVersion = $sender->ConfidenceModel->getCoreVersion();
     
     echo '<div class="Box AddonBox VersionsBox">';
     echo Wrap(T('Community Confidence'), 'h3');
-    if($confidence->TotalVotes > 10 || $confidence->TotalWeight >= 25) {
-        echo Wrap(sprintf(T('The community has confidence this plugin works with Vanilla %s.'), $confidence->CoreVersion), 'p');
+    
+    if(!$confidence) {
+        echo Wrap(sprintf(T('Vanilla %s: NONE'), $coreVersion->Version), 'p');
+    }
+    else if ($confidence->TotalVotes > 10 || $confidence->TotalWeight >= 25) {
+        echo Wrap(sprintf(T('Vanilla %s: HIGH'), $coreVersion->Version), 'p');
     }
     else {
-        echo Wrap(sprintf(T('There is little confidence this plugin works with Vanilla %s.'), $confidence->CoreVersion), 'p');
+        echo Wrap(sprintf(T('Vanilla %s: LOW'), $coreVersion->Version), 'p');
     }
-    writeConfidenceForm($sender->Form, $confidence->CoreVersionID);
+  
+    writeConfidenceForm($sender->Form, $coreVersion->Version);
     echo '</div>';
 }
 
 function writeConfidenceForm($form, $coreVersionID) {
+    if(!Gdn::Session()->IsValid()) {
+        return;
+    }
+    
     echo $form->Open();
     echo $form->Errors();
-    
     echo $form->Hidden('CoreVersionID', $coreVersionID);
     echo Wrap(
             Wrap($form->Label('Confidence', 'Weight'), 'h3') .

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -165,7 +165,8 @@ function writeVersionBox($sender) {
 }
 
 function writeConfidenceBox($sender) {
-    $confidence = $sender->ConfidenceModel->getID($sender->Data('Versions')[0]['AddonVersionID'], DATASET_TYPE_OBJECT);
+    $addonVersionID = $sender->Data('Versions')[0]['AddonVersionID'];
+    $confidence = $sender->ConfidenceModel->getID($addonVersionID, DATASET_TYPE_OBJECT);
     $coreVersion = $sender->ConfidenceModel->getCoreVersion();
     
     echo '<div class="Box AddonBox VersionsBox">';
@@ -181,21 +182,15 @@ function writeConfidenceBox($sender) {
         echo Wrap(sprintf(T('Vanilla %s: LOW'), $coreVersion->Version), 'p');
     }
   
-    writeConfidenceForm($sender->Form, $coreVersion->Version);
+    writeConfidenceForm($addonVersionID, $coreVersion->AddonVersionID);
     echo '</div>';
 }
 
-function writeConfidenceForm($form, $coreVersionID) {
+function writeConfidenceForm($addonID, $coreID) {
     if(!Gdn::Session()->IsValid()) {
         return;
     }
     
-    echo $form->Open();
-    echo $form->Errors();
-    echo $form->Hidden('CoreVersionID', $coreVersionID);
-    echo Wrap(
-            Wrap($form->Label('Confidence', 'Weight'), 'h3') .
-            $form->TextBox('Weight'),
-            'div');
-    echo $form->Close('Save');
+    echo anchor(t('Works'), "/addon/works/$addonID/$coreID", ['class' => 'Button Hijack']);
+    echo anchor(t('Broken'), "/addon/broken/$addonID/$coreID", ['class' => 'Button Hijack']);
 }

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -165,5 +165,28 @@ function writeVersionBox($sender) {
 }
 
 function writeConfidenceBox($sender) {
-    return;
+    $confidence = $sender->ConfidenceModel->getID($sender->Data('Versions')[0]['AddonVersionID'], DATASET_TYPE_OBJECT);
+    
+    echo '<div class="Box AddonBox VersionsBox">';
+    echo Wrap(T('Community Confidence'), 'h3');
+    if($confidence->TotalVotes > 10 || $confidence->TotalWeight >= 25) {
+        echo Wrap(sprintf(T('The community has confidence this plugin works with Vanilla %s.'), $confidence->CoreVersion), 'p');
+    }
+    else {
+        echo Wrap(sprintf(T('There is little confidence this plugin works with Vanilla %s.'), $confidence->CoreVersion), 'p');
+    }
+    writeConfidenceForm($sender->Form, $confidence->CoreVersionID);
+    echo '</div>';
+}
+
+function writeConfidenceForm($form, $coreVersionID) {
+    echo $form->Open();
+    echo $form->Errors();
+    
+    echo $form->Hidden('CoreVersionID', $coreVersionID);
+    echo Wrap(
+            Wrap($form->Label('Confidence', 'Weight'), 'h3') .
+            $form->TextBox('Weight'),
+            'div');
+    echo $form->Close('Save');
 }


### PR DESCRIPTION
This adds a community confidence rating to addons.

It is a work in progress.

* [x] Detect Vanilla (core) versions
* [x] Display community rating of plugins in addon page
* [ ] Display current community rating in addons list
* [x] Thumb up/down voting
* [ ] View past confidence level for core versions
* [ ] Denormalized data for recent core versions