### PR TITLE
Replace "installations" with "downloads"

### DIFF
--- a/applications/vforg/views/home/index.php
+++ b/applications/vforg/views/home/index.php
@@ -187,7 +187,7 @@ function Alt($Alt) {
                 </script>
 
                 <div class="Text">
-                    Vanilla provides cloud and open source community forum software that powers discussion forums on 823,234 sites.
+                    Vanilla provides cloud and open source community forum software that powers discussion forums worldwide with over 832,276 downloads.
                     Built for flexibility and integration, <strong>Vanilla is the best, most powerful community solution in the world.</strong>
                 </div>
             </div>


### PR DESCRIPTION
Replace "installations" with "downloads". Fixes http://vanillaforums.org/discussion/comment/233381/#Comment_233381

Ignore this PR if the number really reflects the current installation base as e.g. indicated by your vanilla statistics collector.
I have taken the updated number of downloads from http://vanillaforums.org/addon/vanilla-core