### PR TITLE
Fix icon on single addon view

### DIFF
--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -419,7 +419,7 @@ class AddonModel extends Gdn_Model {
 
         if (is_a($Data, 'Gdn_DataSet')) {
             $this->setCalculatedFields($Data->result());
-        } elseif (is_object($Data) || !isset($Data[0])) {
+        } elseif (is_object($Data) || isset($Data['Icon'])) {
             $File = val('File', $Data);
             setValue('Url', $Data, Gdn_Upload::url($File));
 


### PR DESCRIPTION
Array[0] is always set, even on an associative array. Instead, detect a known key.