### PR TITLE
Set the addon ID when updating an addon

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -285,6 +285,7 @@ class AddonController extends AddonsController {
         if ($this->Form->authenticatedPostBack()) {
             $AnalyzedAddon = $this->handleAddonUpload();
             $AnalyzedAddon['AddonID'] = $AddonID;
+            $this->Form->setFormValue('AddonID', $AddonID);
 
             // If there were no errors, save the addon version.
             if ($this->Form->errorCount() == 0) {

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -551,6 +551,9 @@ class AddonModel extends Gdn_Model {
         if ($Insert) {
             $this->addInsertFields($Addon);
         }
+        else {
+            $Addon['AddonID'] = val('AddonID', $CurrentAddon, null);
+        }
 
         $this->addUpdateFields($Addon); // always add update fields
 

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -551,9 +551,6 @@ class AddonModel extends Gdn_Model {
         if ($Insert) {
             $this->addInsertFields($Addon);
         }
-        else {
-            $Addon['AddonID'] = val('AddonID', $CurrentAddon, null);
-        }
 
         $this->addUpdateFields($Addon); // always add update fields
 


### PR DESCRIPTION
In the refactor of handling uploads, the set form value is called. This prevented updating of existing addons.

This adds the addon id to the form's value right before saving.