### PR TITLE
Only set Description2 if README exists

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -336,7 +336,10 @@ class AddonController extends AddonsController {
 
             // If the long description is blank, load up the readme if it exists
             if (val('Description2', $AnalyzedAddon, '') == '') {
-                $AnalyzedAddon['Description2'] = $this->parseReadme($TargetPath);
+                $Readme = $this->parseReadme($TargetPath);
+                if ($Readme) {
+                    $AnalyzedAddon['Description2'] = $Readme;
+                }
             }
 
             // Get an icon if one exists.


### PR DESCRIPTION
Fixes NewVersion upload overwriting a manually-entered description when no README was included.