### PR TITLE
Add GitHub location field to addons

### DIFF
--- a/applications/addons/settings/structure.php
+++ b/applications/addons/settings/structure.php
@@ -51,6 +51,7 @@ $Construct->primaryKey('AddonID')
     ->column('Checked', 'tinyint(1)', '0')
     ->column('Official', 'tinyint(1)', '0')
     ->column('License', 'varchar(100)')
+    ->column('GitHub', 'varchar(100)')
     ->set($Explicit, $Drop);
 
 if (!$Description2Exists) {

--- a/applications/addons/views/addon/addon.php
+++ b/applications/addons/views/addon/addon.php
@@ -84,6 +84,12 @@ if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
                         echo wrap(htmlspecialchars($this->data('License')), 'dd');
                     }
 
+                    if ($this->data('GitHub')) {
+                        echo wrap(t('GitHub'), 'dt');
+                        $github = stringBeginsWith($this->data('GitHub'), 'https://github.com/', false, true);
+                        echo wrap(anchor(htmlspecialchars($github), 'https://github.com/'.$github), 'dd');
+                    }
+
                     $this->fireEvent('AddonProperties');
                     ?>
                 </dl>


### PR DESCRIPTION
Adding a 'GitHub' key to your $PluginInfo array will now add a link to the addon page.

Example:

```
$PluginInfo['bot'] = array(
    'Name' => 'Bot',
    'Description' => 'Program your own bot to reply to catch phrases and special conditions.',
    'Version'     => '1.2',
    'MobileFriendly' => true,
    'Author' => "Lincoln Russell",
    'GitHub' => 'linc/vanilla-bot',
    'License' => 'GNU GPL2'
);
```