### PR TITLE
Fix multiple AddonModel notices in PHP7

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -150,7 +150,7 @@ class AddonController extends AddonsController {
             $this->Form->setValidationResults($this->AddonModel->validationResults());
         }
 
-        $Addon = $this->AddonModel->getID($AddonID, true);
+        $Addon = $this->AddonModel->getID($AddonID, false, ['GetVersions' => true]);
         $AddonTypes = Gdn::sql()->get('AddonType')->resultArray();
         $AddonTypes = Gdn_DataSet::index($AddonTypes, 'AddonTypeID');
 
@@ -313,6 +313,7 @@ class AddonController extends AddonsController {
         $Upload = new Gdn_Upload();
         $Upload->allowFileExtension(null);
         $Upload->allowFileExtension('zip');
+        $AnalyzedAddon = [];
 
         try {
             // Validate the upload.
@@ -564,7 +565,7 @@ class AddonController extends AddonsController {
             if (!$Addon) {
                 throw notFoundException();
             }
-            $this->AddonModel->delete($AddonID);
+            $this->AddonModel->hide($AddonID);
             $this->RedirectUrl = url('/addons');
         }
 

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -326,20 +326,20 @@ class AddonModel extends Gdn_Model {
      */
     public function getSlug($slug, $getVersions = false) {
         if (is_numeric($slug)) {
-            $addon = $this->getID($slug, false, ['GetVersion' => $getVersions]);
+            $addon = $this->getID($slug, false, ['GetVersions' => $getVersions]);
         } else {
             // This is a string identifier for the addon.
             $parts = explode('-', $slug, 3);
             $key = val(0, $parts);
 
             if (is_numeric($key)) {
-                $addon = $this->getID($key, false, ['GetVersion' => $getVersions]);
+                $addon = $this->getID($key, false, ['GetVersions' => $getVersions]);
             } else {
                 $type = strtolower(val(1, $parts));
                 $typeID = val($type, self::$Types, 0);
                 $version = val(2, $parts);
 
-                $addon = $this->getID(array($key, $typeID, $version), false, ['GetVersion' => $getVersions]);
+                $addon = $this->getID(array($key, $typeID, $version), false, ['GetVersions' => $getVersions]);
             }
         }
 
@@ -354,7 +354,7 @@ class AddonModel extends Gdn_Model {
             $maxVersion = valr('Versions.0', $addon);
             $foundMax = false;
             $viewingVersion = false;
-            if (count(val('Versions', $addon))) {
+            if (is_array(val('Versions', $addon))) {
                 foreach ($addon['Versions'] as $version) {
                     // Find the version we are looking at.
                     $versionSlug = AddonModel::slug($addon, $version);
@@ -382,7 +382,7 @@ class AddonModel extends Gdn_Model {
             }
 
             $addon['CurrentAddonVersionID'] = $maxVersion['AddonVersionID'];
-            $addon = array_merge($addon, $viewingVersion);
+            $addon = array_merge($addon, (array)$viewingVersion);
             $addon['Slug'] = AddonModel::slug($addon, $viewingVersion);
         }
 

--- a/applications/addons/settings/about.php
+++ b/applications/addons/settings/about.php
@@ -3,7 +3,7 @@
 $ApplicationInfo['Addons'] = [
     'Name' => 'Addons Directory',
     'Description' => "The addon management tool for VanillaForums.org.",
-    'Version' => '1.5',
+    'Version' => '1.5.1',
     'RequiredApplications' => ['Vanilla' => '2.2'],
     'Author' => "Vanilla Community",
     'AuthorEmail' => 'support@vanillaforums.com',


### PR DESCRIPTION
* Fix mismatching signature in `AddonModel::getID()` with several usage fixes.
* Fix mismatching signature in `AddonModel::save()` & `AddonModel::validate()`- no usages need updating.
* Fix mismatching signature in `AddonModel::delete()` by renaming to 'hide'.
* Fix declaration of `$AnalyzedAddon`.
* Fix array detection in `AddonModel::getSlug()`.