### PR TITLE
Use an icon specified in the info array

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -351,7 +351,7 @@ class AddonController extends AddonsController {
             }
 
             // Get an icon if one exists.
-            $Icon = $this->extractIcon($TargetPath);
+            $Icon = $this->extractIcon($TargetPath, val('Icon', $AnalyzedAddon));
             if ($Icon) {
                 $AnalyzedAddon['Icon'] = $Icon;
             }
@@ -920,9 +920,10 @@ class AddonController extends AddonsController {
      * @throws Exception
      * @throws Gdn_UserException
      */
-    protected function extractIcon($path) {
+    protected function extractIcon($path, $name = '') {
         $icon = null;
-        $entries = UpdateModel::findFiles($path, ['icon.png']);
+        $name = ($name !== '') ? [$name] : ['icon.png'];
+        $entries = UpdateModel::findFiles($path, $name);
 
         // Success should be exactly 1 file matching.
         if (count($entries) == 1) {

--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -351,8 +351,9 @@ class AddonController extends AddonsController {
             }
 
             // Get an icon if one exists.
-            $Icon = $this->extractIcon($TargetPath, val('Icon', $AnalyzedAddon));
+            $Icon = $this->extractIcon($TargetPath, val('Icon', $AnalyzedAddon, ''));
             if ($Icon) {
+                // Overwrite info array value with the path to the saved file.
                 $AnalyzedAddon['Icon'] = $Icon;
             }
 
@@ -905,7 +906,8 @@ class AddonController extends AddonsController {
         $uploadImage = new Gdn_UploadImage();
 
         // Generate the target image name
-        $targetLocation = $uploadImage->generateTargetName('addons/icons', '');
+        $extension = val('extension', pathinfo($imageLocation), '');
+        $targetLocation = $uploadImage->generateTargetName('addons/icons', $extension);
 
         // Save the uploaded icon
         $parsed = $uploadImage->saveImageAs($imageLocation, $targetLocation, 256, 256, false, false);

--- a/applications/addons/settings/about.php
+++ b/applications/addons/settings/about.php
@@ -3,7 +3,7 @@
 $ApplicationInfo['Addons'] = [
     'Name' => 'Addons Directory',
     'Description' => "The addon management tool for VanillaForums.org.",
-    'Version' => '1.5.1',
+    'Version' => '1.5.2',
     'RequiredApplications' => ['Vanilla' => '2.2'],
     'Author' => "Vanilla Community",
     'AuthorEmail' => 'support@vanillaforums.com',


### PR DESCRIPTION
Specifying `'Icon' => 'whatever.png'` in the addon info array currently breaks the system because it's only looking for a file named `icon.png`. This lets an addon's specified image file take precedence (and skips looking for icon.png in that case).

Also fixes related issue with getting the extension of the icon. It's not the primary file being uploaded, so it can't use the default detection in the upload object.

Closes #98 