### PR TITLE
Update addon search to show locale en names and completeness

### DIFF
--- a/applications/addons/views/addon/addon.php
+++ b/applications/addons/views/addon/addon.php
@@ -59,7 +59,7 @@ if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
                     // Special Locale-only info.
                     if ($this->data('Type') == 'Locale') {
                         if ($this->data('EnName')) {
-                            echo wrap(t('Name (EN)'), 'dt');
+                            echo wrap(t('Name (en)'), 'dt');
                             echo wrap(htmlspecialchars($this->data('EnName')), 'dd');
                         }
                         if ($this->data('PercentComplete')) {

--- a/applications/addons/views/addon/addon.php
+++ b/applications/addons/views/addon/addon.php
@@ -63,7 +63,7 @@ if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
                             echo wrap(htmlspecialchars($this->data('EnName')), 'dd');
                         }
                         if ($this->data('PercentComplete')) {
-                            echo wrap(t('Completeness'), 'dt');
+                            echo wrap(t('Translated'), 'dt');
                             echo wrap(htmlspecialchars($this->data('PercentComplete').'%'), 'dd');
                         }
                     }

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -17,16 +17,26 @@ function writeAddon($Addon, $Alt) {
         ?>
         <div class="ItemContent">
             <?php
-            echo anchor($Addon->Name, $Url, 'Title');
+            $name = ($Addon->Type === 'Locale' && $Addon->EnName != '') ? $Addon->Name.' / '.$Addon->EnName : $Addon->Name;
+            echo anchor(htmlspecialchars($name), $Url, 'Title');
 
             echo '<div class="Description">', anchor(sliceString(Gdn_Format::text($Addon->Description), 300), $Url), '</div>';
             ?>
             <div class="Meta">
                 <span class="TypeTag"><?php echo $Addon->Type; ?></span>
+                <?php if ($Addon->Type === 'Locale') : ?>
+                    <?php if (!is_null($Addon->PercentComplete)) : ?>
+                <span class="Completeness">
+                    Completeness
+                    <span><?php echo (int)$Addon->PercentComplete.'%'; ?></span>
+                </span>
+                    <?php endif; ?>
+                <?php else : ?>
                 <span class="Version">
                     Version
-                    <span><?php echo $Addon->Version; ?></span>
+                    <span><?php echo htmlspecialchars($Addon->Version); ?></span>
                 </span>
+                <?php endif; ?>
                 <span class="Author">
                     Author
                     <span><?php echo val('Official', $Addon) ? t('Vanilla Staff') : $Addon->InsertName; ?></span>

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -20,7 +20,7 @@ function writeAddon($Addon, $Alt) {
             $name = ($Addon->Type === 'Locale' && $Addon->EnName != '') ? $Addon->Name.' / '.$Addon->EnName : $Addon->Name;
             echo anchor(htmlspecialchars($name), $Url, 'Title');
 
-            echo '<div class="Description">', anchor(sliceString(Gdn_Format::text($Addon->Description), 300), $Url), '</div>';
+            echo '<div class="Description">', anchor(htmlspecialchars(sliceString(Gdn_Format::text($Addon->Description), 300)), $Url), '</div>';
             ?>
             <div class="Meta">
                 <span class="TypeTag"><?php echo $Addon->Type; ?></span>
@@ -39,7 +39,7 @@ function writeAddon($Addon, $Alt) {
                 <?php endif; ?>
                 <span class="Author">
                     Author
-                    <span><?php echo val('Official', $Addon) ? t('Vanilla Staff') : $Addon->InsertName; ?></span>
+                    <span><?php echo val('Official', $Addon) ? t('Vanilla Staff') : htmlspecialchars($Addon->InsertName); ?></span>
                 </span>
                 <span class="Downloads">
                     Downloads

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -17,14 +17,19 @@ function writeAddon($Addon, $Alt) {
         ?>
         <div class="ItemContent">
             <?php
-            $name = ($Addon->Type === 'Locale' && $Addon->EnName != '') ? $Addon->Name.' / '.$Addon->EnName : $Addon->Name;
-            echo anchor(htmlspecialchars($name), $Url, 'Title');
+            echo anchor(htmlspecialchars($Addon->Name), $Url, 'Title');
 
             echo '<div class="Description">', anchor(htmlspecialchars(sliceString(Gdn_Format::text($Addon->Description), 300)), $Url), '</div>';
             ?>
             <div class="Meta">
                 <span class="TypeTag"><?php echo $Addon->Type; ?></span>
                 <?php if ($Addon->Type === 'Locale') : ?>
+                    <?php if (!is_null($Addon->EnName)) : ?>
+                <span class="EnName">
+                    Name (en)
+                    <span><?php echo htmlspecialchars($Addon->EnName); ?></span>
+                </span>
+                    <?php endif; ?>
                     <?php if (!is_null($Addon->PercentComplete)) : ?>
                 <span class="Completeness">
                     Completeness

--- a/applications/addons/views/addon/helper_functions.php
+++ b/applications/addons/views/addon/helper_functions.php
@@ -31,8 +31,8 @@ function writeAddon($Addon, $Alt) {
                 </span>
                     <?php endif; ?>
                     <?php if (!is_null($Addon->PercentComplete)) : ?>
-                <span class="Completeness">
-                    Completeness
+                <span class="PercentComplete">
+                    Translated
                     <span><?php echo (int)$Addon->PercentComplete.'%'; ?></span>
                 </span>
                     <?php endif; ?>
@@ -52,7 +52,7 @@ function writeAddon($Addon, $Alt) {
                 </span>
                 <span class="Updated">
                     Updated
-                    <span><?php echo Gdn_Format::date($Addon->DateUpdated); ?></span>
+                    <span><?php echo Gdn_Format::date($Addon->DateUpdated, 'html'); ?></span>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
Fixes #105 

Uses this name format for locales (when EnName is available):  Name / EnName

Omits "version" in favor of "completeness" for locales to keep the meta info pithy.

Adds some html escaping.