### PR TITLE
Fix the vforg theme key

### DIFF
--- a/themes/vforg/about.php
+++ b/themes/vforg/about.php
@@ -1,9 +1,9 @@
 <?php if (!defined('APPLICATION')) exit();
 
-$ThemeInfo['VanillaForums.org'] = array(
+$ThemeInfo['vforg'] = array(
    'Name' => 'VanillaForums.org',
    'Description' => "A custom theme for VanillaForums.org.",
-   'Version' => '1.7',
+   'Version' => '2.0.0',
    'Author' => "Mark O'Sullivan",
    'AuthorEmail' => 'mark@vanillaforums.com',
    'AuthorUrl' => 'http://markosullivan.ca',


### PR DESCRIPTION
The theme key MUST be the same as the theme folder. This will break the new addon manager otherwise.