### PR TITLE
Prevent border clipping on Profile Reaction pages

### DIFF
--- a/themes/vforg/sass/custom.scss
+++ b/themes/vforg/sass/custom.scss
@@ -473,6 +473,10 @@ a.RenderedDownloadButton span {
     display: none;
 }
 
+.DataCounts .CountItemWrap {
+   min-width: 10%;
+}
+
 .Reactions .Count {
     background: #012f6e;
     color: #fff;


### PR DESCRIPTION
Pertaining to the border of the selected reaction. E.g. https://vanillaforums.org/profile/reactions/hgtonight?reaction=insightful

Also works on short counts like '0', e.g. https://vanillaforums.org/profile/reactions/dmsinger?reaction=awesome