### PR TITLE
Make it easier to request all current versions of active plugins

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -978,6 +978,23 @@ class AddonController extends AddonsController {
 
         $this->render('browse');
     }
+    public function version($IDstring='')
+    {
+        $IDs=explode(",",$IDstring);
+        $json=new stdClass();
+        $json->plugins=new stdClass();
+        foreach($IDs as $pluginName)
+        {
+            $Addon = $this->AddonModel->getID([$pluginName,1]);
+            if (is_array($Addon)) {
+                $json->plugins->$pluginName=$Addon['Version'];                
+            }
+            else{
+                $json->plugins->$pluginName=false;     
+            }
+        }
+        echo json_encode($json);
+    }
 
     /**
      * Set the icon for an addon.


### PR DESCRIPTION
See https://vanillaforums.org/discussion/32688/plugin-security#latest

Hey all,

A while back I found my first XSS vulnerability in a plugin (I was so proud of my L33t H4ck0r skillz!), and after notifying the creator it was fixed immidiately.

However, that got me thinking: There's not a good way yet to keep up to date on security with the plugins you have. Of course, people point out security flaws on the forum, but it's easily missable if you don't read every thread.

With the new method you can request https://vanillaforums.org/addons/version/ButtonBar,Debugger,VanillaStats and get a JSON formatted list of the current versions of those plugins back.

It's then possible to write a security plugin that checks every week all active plugins for more recent updates, and notifies the administrator of old plugins.