### PR TITLE
Use copylocal to do addon checks

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -274,7 +274,8 @@ class AddonController extends AddonsController {
         }
 
         // Get the data for the most recent version of the addon.
-        $Path = PATH_UPLOADS.'/'.$Addon['File'];
+        $upload = new Gdn_Upload(); // Also used per version below.
+        $Path = $upload->copyLocal($Addon['File']);
 
         $AddonData = arrayTranslate(
             (array)$Addon,
@@ -299,6 +300,7 @@ class AddonController extends AddonsController {
                 );
                 $AddonData['File_Type'] = valr($FileAddonData['AddonTypeID'].'.Label', $AddonTypes, 'Unknown');
             }
+            $upload->delete($Addon['File']);
         } catch (Exception $Ex) {
             $AddonData['File_Error'] = $Ex->getMessage();
         }
@@ -308,7 +310,7 @@ class AddonController extends AddonsController {
         $Versions = array();
         foreach ($Addon['Versions'] as $Version) {
             $Version = $Version;
-            $Path = PATH_UPLOADS."/{$Version['File']}";
+            $Path = $upload->copyLocal($Version['File']);
 
             try {
                 $VersionData = arrayTranslate(
@@ -328,6 +330,7 @@ class AddonController extends AddonsController {
                         'Checked' => 'File_Checked'
                     )
                 );
+                $upload->delete($Version['File']);
             } catch (Exception $Ex) {
                 $FileVersionData = array('File_Error' => $Ex->getMessage());
             }

--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -300,7 +300,7 @@ class AddonController extends AddonsController {
                 );
                 $AddonData['File_Type'] = valr($FileAddonData['AddonTypeID'].'.Label', $AddonTypes, 'Unknown');
             }
-            $upload->delete($Addon['File']);
+            $upload->delete($Path);
         } catch (Exception $Ex) {
             $AddonData['File_Error'] = $Ex->getMessage();
         }
@@ -330,7 +330,7 @@ class AddonController extends AddonsController {
                         'Checked' => 'File_Checked'
                     )
                 );
-                $upload->delete($Version['File']);
+                $upload->delete($Path);
             } catch (Exception $Ex) {
                 $FileVersionData = array('File_Error' => $Ex->getMessage());
             }


### PR DESCRIPTION
Because files are on the CDN, they cannot be analyzed locally without using `copyLocal()`. We then delete the copied file so we don't end up with a bunch of local copies.

Closes #106