### PR TITLE
Remove ProxyFeed from vforg application

### DIFF
--- a/applications/vforg/settings/class.hooks.php
+++ b/applications/vforg/settings/class.hooks.php
@@ -96,24 +96,6 @@ class VFOrgHooks extends Gdn_Plugin {
     }
 
     /**
-     * Proxy an RSS feed for Dashboard use across our kingdom.
-     *
-     * @param Gdn_Controller $sender
-     * @param $Url
-     * @return mixed|string
-     * @throws Exception
-     */
-    public function homeController_proxyFeed_create($sender, $Url) {
-        $Key = 'Feed|'.$Url;
-        $Feed = Gdn::cache()->get($Key);
-        if (!$Feed) {
-            $Feed = ProxyRequest($Url, 5);
-            Gdn::cache()->store($Key, $Feed, array(Gdn_Cache::FEATURE_EXPIRY => 5 * 60));
-        }
-        return $Feed;
-    }
-
-    /**
      * Splish splash I was takin' a... modal ad for cloud?
      *
      * @param Gdn_Controller $sender


### PR DESCRIPTION
The vforg application originally had its own `HomeController` class. This controller had a `ProxyFeed` method, added in 13444f3344cbabe225dd892c48c1d05f6c03a53a, that would consume a feed and cache its results. Its usage was subsequently commented out with 450c15d7a39bf43b1d5dd52837a2fb8cdb8a20e4 and finally removed with e43991618b9c5ad300bcc5693a6750e1e55723a1. However, the method was never removed. When the vforg `HomeController` was removed and its relevant pages were carried over to its hooks file in a02add50b08cdd7699340e40c99fc644f1fef694, the unused `ProxyFeed` function was carried over as a page. It remains there, seemingly unneeded and unused.

This update purges the /home/proxyfeed endpoint from the vforg application.