### PR TITLE
Add 'official' filter to addons directory and clarify navigation text & headings

### DIFF
--- a/applications/addons/controllers/class.addoncontroller.php
+++ b/applications/addons/controllers/class.addoncontroller.php
@@ -770,24 +770,27 @@ class AddonController extends AddonsController {
 
         switch ($this->Filter) {
             case 'themes':
-                $Title = 'Browse All Themes';
+                $context = 'All Themes';
                 break;
             case 'locales':
-                $Title = 'Browse All Locales';
+                $context = 'All Locales';
                 break;
             case 'plugins,applications':
-                $Title = 'Browse All Plugins';
+                $context = 'All Plugins';
                 break;
             case 'core':
-                $Title = 'Official Products and Plugins';
+                $context = 'Official Products and Plugins';
                 break;
             default:
-                $Title = 'Browse All Types of Addons';
+                $context = 'All Types of Addons';
                 break;
         }
-        $this->setData('Title', $Title);
 
-        $Search = GetIncomingValue('Keywords', '');
+        $Search = getIncomingValue('Keywords', '');
+
+        $action = ($Search) ? 'Searching' : 'Browsing';
+        $this->setData('Title', "$action $context");
+
         $this->buildBrowseWheres($Search);
 
         $SortField = $Sort == 'recent' ? 'DateUpdated' : 'CountDownloads';
@@ -853,8 +856,10 @@ class AddonController extends AddonsController {
         // This is so gross, I'm so sorry. -Linc
         if ($Types == 'core') {
             $this->AddonModel->SQL
+                ->beginWhereGroup()
                 ->where('a.AddonTypeID', AddonModel::$Types['core'])
                 ->orWhere(['a.Official' => 1, 'a.AddonTypeID' => AddonModel::$Types['plugin']])
+                ->endWhereGroup()
                 ->orderBy('a.AddonTypeID', 'desc'); // Dirty hack to pin core + porter to top of list.
             return;
         }

--- a/applications/addons/views/addon/head.php
+++ b/applications/addons/views/addon/head.php
@@ -17,23 +17,19 @@ if (!property_exists($this, 'HideSearch')) {
         $Query = '?Keywords='.$Query;
     ?>
     <div class="Options">
-        <strong>↳</strong>
+        <strong>↳</strong> Filter:
         <?php
         $Suffix = $this->Sort.'/'.$Query;
-        ?>
-        Show
-        <?php
         echo anchor('Everything', 'addon/browse/all/'.$Suffix, 'ShowAll' . ($this->Filter == 'all' ? ' Active' : ''));
         echo anchor('Plugins', 'addon/browse/apps/'.$Suffix, $this->Filter == 'plugins,applications' ? 'Active' : '');
         echo anchor('Themes', 'addon/browse/themes/'.$Suffix, $this->Filter == 'themes' ? 'Active' : '');
         echo anchor('Locales', 'addon/browse/locales/'.$Suffix, $this->Filter == 'locales' ? 'Active' : '');
         echo anchor('Official', 'addon/browse/core/'.$Suffix, $this->Filter == 'core' ? 'Active' : '');
-
         ?>
-        <strong>↳</strong> Sorted by most
+        <strong>↳</strong> Sort:
         <?php
-        echo anchor('Recent', $Url.'recent/'.$Suffix, $this->Sort == 'recent' ? 'Active' : '');
-        echo anchor('Popular', $Url.'popular/'.$Suffix, $this->Sort == 'popular' ? 'Active' : '');
+        echo anchor('Last Updated', $Url.'recent/'.$Suffix, $this->Sort == 'recent' ? 'Active' : '');
+        echo anchor('Most Downloads', $Url.'popular/'.$Suffix, $this->Sort == 'popular' ? 'Active' : '');
         ?>
     </div>
     <?php

--- a/applications/addons/views/addon/head.php
+++ b/applications/addons/views/addon/head.php
@@ -24,10 +24,10 @@ if (!property_exists($this, 'HideSearch')) {
         Show
         <?php
         echo anchor('Everything', 'addon/browse/all/'.$Suffix, 'ShowAll' . ($this->Filter == 'all' ? ' Active' : ''));
-        echo anchor('Plugins/Apps', 'addon/browse/apps/'.$Suffix, $this->Filter == 'plugins,applications' ? 'Active' : '');
+        echo anchor('Plugins', 'addon/browse/apps/'.$Suffix, $this->Filter == 'plugins,applications' ? 'Active' : '');
         echo anchor('Themes', 'addon/browse/themes/'.$Suffix, $this->Filter == 'themes' ? 'Active' : '');
         echo anchor('Locales', 'addon/browse/locales/'.$Suffix, $this->Filter == 'locales' ? 'Active' : '');
-        echo anchor('Core', 'addon/browse/core/'.$Suffix, $this->Filter == 'core' ? 'Active' : '');
+        echo anchor('Official', 'addon/browse/core/'.$Suffix, $this->Filter == 'core' ? 'Active' : '');
 
         ?>
         <strong>↳</strong> Sorted by most

--- a/applications/addons/views/addon/head.php
+++ b/applications/addons/views/addon/head.php
@@ -10,7 +10,7 @@ if (!property_exists($this, 'HideSearch')) {
     echo $this->Form->open(array('action' => url($Url.$this->Sort)));
     echo $this->Form->errors();
     echo $this->Form->textBox('Keywords', array('value' => $Query));
-    echo $this->Form->button('Browse Addons');
+    echo $this->Form->button('Search Addons');
 
     $Query = urlencode($Query);
     if ($Query != '')


### PR DESCRIPTION
This swaps the "Core" filter for an "Official" filter on the addons directory.

Current situation:
* The Core filter only ever returned 2 things which, while useful, is extremely unlikely to be used for anything else in the future.
* It's currently a pain to find the addons we're supposed to be maintaining ourselves (the company).
* There's no indication when you are searching beyong text in the search box.

UX Changes:
* New "Official" filter groups Core addons with ones marked as Official, and pins the 2 Core addons to the top of the list.
* Rename "Plugins/Apps" to just "Plugins" since we are deprecating apps.
* Improve the page heading for all the different filter options.
* Specify whether "Searching" or "Browsing" in page heading.
* Change "Show" and "Sort by most" labels to "Filter:" and "Sort:" respectively.
* Change sort options from "Recent" and "Popular" (vague) to "Last Updated" and "Most Downloads".
* Change search button to say "Search Addons" instead of "Browse Addons".

Code Changes:
* Remove dead filters the rest of the way (checked, FilterVanilla).
* New SQL for the weirdness of the Official conditions.
* More sassy comments to make our depravity clearer.

My goal was merely to make a quality-neutral change to this application.

Old navigation:
<img width="827" alt="screen shot 2019-02-10 at 3 39 46 pm" src="https://user-images.githubusercontent.com/117672/52539282-3e720380-2d4a-11e9-95c7-72712e8cbfa5.png">

New navigation:
<img width="817" alt="screen shot 2019-02-10 at 3 42 33 pm" src="https://user-images.githubusercontent.com/117672/52539306-86912600-2d4a-11e9-99ac-54b44ea62d56.png">


