### PR TITLE
Allow dashes in addon keys

### DIFF
--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -786,7 +786,7 @@ class AddonModel extends Gdn_Model {
 function validateAddonKey($Value) {
     if (is_numeric($Value)) {
         return false;
-    } elseif (preg_match('`[-,;:/]`', $Value) || strpos($Value, '\\') !== false) {
+    } elseif (preg_match('`[,;:/]`', $Value) || strpos($Value, '\\') !== false) {
         return false;
     }
     return true;


### PR DESCRIPTION
Closes https://github.com/vanilla/community/issues/151

`-` is used in some of our own addon keys, and is used in the example in our docs.

https://docs.vanillaforums.com/developer/addons/addon-info/#addon-json-example

Also see `rich-editor`.