### PR TITLE
Remove 30 day free-trial from the download page.

### DIFF
--- a/applications/addons/views/download/index.php
+++ b/applications/addons/views/download/index.php
@@ -37,5 +37,5 @@
          <h1>Big Communities</h1>
          <p>Get help hosting &amp; growing your community</p>
      </div>
-     <?php echo anchor(wrap('<strong>See Plans &amp; Pricing</strong> 30-day Free Trial. Take control of your community.'), 'http://vanillaforums.com/plans', 'RenderedDownloadButton'); ?>
+     <?php echo anchor(wrap('<strong>See Plans &amp; Pricing</strong>Take control of your community.'), 'https://vanillaforums.com/plans', 'RenderedDownloadButton'); ?>
 </div>


### PR DESCRIPTION
This PR will close https://github.com/vanilla/support/issues/370

In the downloads view we reference a 30 day free-trial that is no longer offered.