### PR TITLE
Feature/allow dashes in addon keys

### DIFF
--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -280,12 +280,12 @@ class AddonModel extends Gdn_Model {
         // Loop through all of the IDs and parse them out.
         foreach ($IDs as $ID) {
             $parts = explode('-', $ID, 3);
-			$parts = $this->getSlug($ID);
+            $parts = $this->getSlug($ID);
 
             if (is_numeric($parts['key'])) {
                 $addonIDs[] = $parts['key'];
             } else {
-				$addonTypeIDs[$parts['typeID']][] = $parts['key'];
+                $addonTypeIDs[$parts['typeID']][] = $parts['key'];
             }
         }
         $result = [];
@@ -322,21 +322,21 @@ class AddonModel extends Gdn_Model {
      * @return array
      */
     public function getSlug($slug, $getVersions = false) {
-		// This is a string identifier for the addon.
-		$parts = $this->parseSlug($slug);
-		if ($parts == []) {
-			return false;
-		}
+        // This is a string identifier for the addon.
+        $parts = $this->parseSlug($slug);
+        if ($parts == []) {
+            return false;
+        }
 
-		if (is_numeric($parts['key'])) {
-			$addon = $this->getID($parts['key'], false, ['GetVersions' => $getVersions]);
-		} else {
-			$addon = $this->getID(
-				[$parts['key'], $parts['typeID'], $parts['version']					],
-				false,
-				['GetVersions' => $getVersions]
-			);
-		}
+        if (is_numeric($parts['key'])) {
+            $addon = $this->getID($parts['key'], false, ['GetVersions' => $getVersions]);
+        } else {
+            $addon = $this->getID(
+                [$parts['key'], $parts['typeID'], $parts['version']                    ],
+                false,
+                ['GetVersions' => $getVersions]
+            );
+        }
 
         if (!$addon) {
             return false;
@@ -770,56 +770,56 @@ class AddonModel extends Gdn_Model {
             $this->SQL->history()->put('Addon', array('CurrentAddonVersionID' => $MaxVersion->Version), array('AddonID' => $AddonID));
         }
     }
-	
-	/**
-	 * Parse a slug and returns information array about the plugin.
-	 *
-	 * Possible values of the returned array are:
-	 *   - version: the Version number
-	 *   - type: one of self::$Types
-	 *   - typeID: numeric key for Vanilla's addon types
-	 *   - key: the key of the plugin
-	 *
-	 * @param string $slug The slug to parse.
-	 *
-	 * @return array Addon info (version, type, type id and key)
-	 */
-	public function parseSlug($slug) {
-		$parts = explode('-', $slug);
-		
-		if (is_numeric($parts[0])) {
-			// Slug is numeric ID.
-			return ['key' => $parts[0]];
-		}
-		
-		$end = array_pop($parts);
-		$type = strtolower($end);
-		if (in_array($type, self::$Types)) {
-			// Slug ends with one of self::Types without version number.
-			return [
-				'version' => false,
-				'type' => $type,
-				'typeID' => self::$Types[$type],
-				'key' => implode('-', $parts)
-			];
-		}
-		
-		// If $end is no addon type, it must the version number.
-		$version = $end;
-		$end = array_pop($parts);
-		if (in_array($end, self::$Types)) {
-			// Slug ends with type and version number.	
-			return [
-				'version' => $version,
-				'type' => $end,
-				'typeID' => self::$Types[$end],
-				'key' => implode('-', $parts)
-			];
-		}
+    
+    /**
+     * Parse a slug and returns information array about the plugin.
+     *
+     * Possible values of the returned array are:
+     *   - version: the Version number
+     *   - type: one of self::$Types
+     *   - typeID: numeric key for Vanilla's addon types
+     *   - key: the key of the plugin
+     *
+     * @param string $slug The slug to parse.
+     *
+     * @return array Addon info (version, type, type id and key)
+     */
+    public function parseSlug($slug) {
+        $parts = explode('-', $slug);
+        
+        if (is_numeric($parts[0])) {
+            // Slug is numeric ID.
+            return ['key' => $parts[0]];
+        }
+        
+        $end = array_pop($parts);
+        $type = strtolower($end);
+        if (in_array($type, self::$Types)) {
+            // Slug ends with one of self::Types without version number.
+            return [
+                'version' => false,
+                'type' => $type,
+                'typeID' => self::$Types[$type],
+                'key' => implode('-', $parts)
+            ];
+        }
+        
+        // If $end is no addon type, it must the version number.
+        $version = $end;
+        $end = array_pop($parts);
+        if (in_array($end, self::$Types)) {
+            // Slug ends with type and version number.    
+            return [
+                'version' => $version,
+                'type' => $end,
+                'typeID' => self::$Types[$end],
+                'key' => implode('-', $parts)
+            ];
+        }
 
-		// Parsing failed.
-		return [];
-	}
+        // Parsing failed.
+        return [];
+    }
 }
 
 /**

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -775,6 +775,55 @@ class AddonModel extends Gdn_Model {
             $this->SQL->history()->put('Addon', array('CurrentAddonVersionID' => $MaxVersion->Version), array('AddonID' => $AddonID));
         }
     }
+	
+	/**
+	 * Parse a slug and returns information array about the plugin.
+	 *
+	 * Possible values of the returned array are:
+	 *   - version: the Version number
+	 *   - type: one of self::$Types
+	 *   - typeID: numeric key for Vanilla's addon types
+	 *   - key: the key of the plugin
+	 *
+	 * @param string $slug The slug to parse.
+	 *
+	 * @return array Addon info (version, type, type id and key)
+	 */
+	public function parseSlug($slug) {
+		$parts = explode('-', $slug);
+		
+		if (is_numeric($parts[0])) {
+			// Slug is numeric ID.
+			return ['key' => $parts[0]];
+		}
+		
+		$end = array_pop($parts);
+		if (in_array($end, self::$Types)) {
+			// Slug ends with one of self::Types without version number.
+			return [
+				'version' => false,
+				'type' => $end,
+				'typeID' => self::$Types[$end],
+				'key' => implode('-', $parts)
+			];
+		}
+		
+		// If $end is no addon type, it must the version number.
+		$version = $end;
+		$end = array_pop($parts);
+		if (in_array($end, self::$Types)) {
+			// Slug ends with type and version number.	
+			return [
+				'version' => $version,
+				'type' => $end,
+				'typeID' => self::$Types[$end],
+				'key' => implode('-', $parts)
+			];
+		}
+
+		// Parsing failed.
+		return [];
+	}
 }
 
 /**

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -325,25 +325,21 @@ class AddonModel extends Gdn_Model {
      * @return array
      */
     public function getSlug($slug, $getVersions = false) {
-        if (is_numeric($slug)) {
-            $addon = $this->getID($slug, false, ['GetVersions' => $getVersions]);
-        } else {
-            // This is a string identifier for the addon.
-			$parts = $this->parseSlug($slug);
-			if ($parts == []) {
-				return false;
-			}
+		// This is a string identifier for the addon.
+		$parts = $this->parseSlug($slug);
+		if ($parts == []) {
+			return false;
+		}
 
-            if (is_numeric($parts['key'])) {
-                $addon = $this->getID($parts['key'], false, ['GetVersions' => $getVersions]);
-            } else {
-                $addon = $this->getID(
-					[$parts['key'], $parts['typeID'], $parts['version']					],
-					false,
-					['GetVersions' => $getVersions]
-				);
-            }
-        }
+		if (is_numeric($parts['key'])) {
+			$addon = $this->getID($parts['key'], false, ['GetVersions' => $getVersions]);
+		} else {
+			$addon = $this->getID(
+				[$parts['key'], $parts['typeID'], $parts['version']					],
+				false,
+				['GetVersions' => $getVersions]
+			);
+		}
 
         if (!$addon) {
             return false;

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -274,21 +274,18 @@ class AddonModel extends Gdn_Model {
      * @return Gdn_DataSet
      */
     public function getIDs($IDs) {
-        $addonTypeIDs = array();
-        $addonIDs = array();
+        $addonTypeIDs = [];
+        $addonIDs = [];
 
         // Loop through all of the IDs and parse them out.
         foreach ($IDs as $ID) {
             $parts = explode('-', $ID, 3);
+			$parts = $this->getSlug($ID);
 
-            if (is_numeric($parts[0])) {
-                $addonIDs[] = $parts[0];
+            if (is_numeric($parts['key'])) {
+                $addonIDs[] = $parts['key'];
             } else {
-                $key = $parts[0];
-                $type = val(1, $parts);
-                if (isset(self::$Types[$type])) {
-                    $addonTypeIDs[self::$Types[$type]][] = $key;
-                }
+				$addonTypeIDs[$parts['typeID']][] = $parts['key'];
             }
         }
         $result = [];

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -274,45 +274,45 @@ class AddonModel extends Gdn_Model {
      * @return Gdn_DataSet
      */
     public function getIDs($IDs) {
-        $AddonTypeIDs = array();
-        $AddonIDs = array();
+        $addonTypeIDs = array();
+        $addonIDs = array();
 
         // Loop through all of the IDs and parse them out.
         foreach ($IDs as $ID) {
-            $Parts = explode('-', $ID, 3);
+            $parts = explode('-', $ID, 3);
 
-            if (is_numeric($Parts[0])) {
-                $AddonIDs[] = $Parts[0];
+            if (is_numeric($parts[0])) {
+                $addonIDs[] = $parts[0];
             } else {
-                $Key = $Parts[0];
-                $Type = val(1, $Parts);
-                if (isset(self::$Types[$Type])) {
-                    $AddonTypeIDs[self::$Types[$Type]][] = $Key;
+                $key = $parts[0];
+                $type = val(1, $parts);
+                if (isset(self::$Types[$type])) {
+                    $addonTypeIDs[self::$Types[$type]][] = $key;
                 }
             }
         }
-        $Result = array();
+        $result = [];
 
         // Get all of the Addons by ID.
-        if (count($AddonIDs) > 0) {
+        if (count($addonIDs) > 0) {
             $this->addonQuery();
-            $Addons = $this->SQL->whereIn('a.AddonID', $AddonIDs)->get()->result();
-            $Result = array_merge($Result, $Addons);
+            $addons = $this->SQL->whereIn('a.AddonID', $addonIDs)->get()->result();
+            $result = array_merge($result, $addons);
         }
 
         // Get all of the Addons by type.
-        foreach ($AddonTypeIDs as $TypeID => $Keys) {
+        foreach ($addonTypeIDs as $typeID => $keys) {
             $this->addonQuery();
-            $Addons = $this->SQL
-                ->where('a.AddonTypeID', $TypeID)
-                ->whereIn('a.AddonKey', $Keys)
+            $addons = $this->SQL
+                ->where('a.AddonTypeID', $typeID)
+                ->whereIn('a.AddonKey', $keys)
                 ->get()->result();
-            $Result = array_merge($Result, $Addons);
+            $result = array_merge($result, $addons);
         }
 
-        $this->setCalculatedFields($Result);
-        $DataSet = new Gdn_DataSet($Result);
-        return $DataSet;
+        $this->setCalculatedFields($result);
+        $dataSet = new Gdn_DataSet($result);
+        return $dataSet;
     }
 
     /**

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -329,17 +329,19 @@ class AddonModel extends Gdn_Model {
             $addon = $this->getID($slug, false, ['GetVersions' => $getVersions]);
         } else {
             // This is a string identifier for the addon.
-            $parts = explode('-', $slug, 3);
-            $key = val(0, $parts);
+			$parts = $this->parseSlug($slug);
+			if ($parts == []) {
+				return false;
+			}
 
-            if (is_numeric($key)) {
-                $addon = $this->getID($key, false, ['GetVersions' => $getVersions]);
+            if (is_numeric($parts['key'])) {
+                $addon = $this->getID($parts['key'], false, ['GetVersions' => $getVersions]);
             } else {
-                $type = strtolower(val(1, $parts));
-                $typeID = val($type, self::$Types, 0);
-                $version = val(2, $parts);
-
-                $addon = $this->getID(array($key, $typeID, $version), false, ['GetVersions' => $getVersions]);
+                $addon = $this->getID(
+					[$parts['key'], $parts['typeID'], $parts['version']					],
+					false,
+					['GetVersions' => $getVersions]
+				);
             }
         }
 
@@ -798,12 +800,13 @@ class AddonModel extends Gdn_Model {
 		}
 		
 		$end = array_pop($parts);
-		if (in_array($end, self::$Types)) {
+		$type = strtolower($end);
+		if (in_array($type, self::$Types)) {
 			// Slug ends with one of self::Types without version number.
 			return [
 				'version' => false,
-				'type' => $end,
-				'typeID' => self::$Types[$end],
+				'type' => $type,
+				'typeID' => self::$Types[$type],
 				'key' => implode('-', $parts)
 			];
 		}

--- a/applications/addons/models/class.addonmodel.php
+++ b/applications/addons/models/class.addonmodel.php
@@ -770,7 +770,7 @@ class AddonModel extends Gdn_Model {
             $this->SQL->history()->put('Addon', array('CurrentAddonVersionID' => $MaxVersion->Version), array('AddonID' => $AddonID));
         }
     }
-    
+
     /**
      * Parse a slug and returns information array about the plugin.
      *
@@ -786,12 +786,12 @@ class AddonModel extends Gdn_Model {
      */
     public function parseSlug($slug) {
         $parts = explode('-', $slug);
-        
+
         if (is_numeric($parts[0])) {
             // Slug is numeric ID.
             return ['key' => $parts[0]];
         }
-        
+
         $end = array_pop($parts);
         $type = strtolower($end);
         if (in_array($type, self::$Types)) {
@@ -803,12 +803,12 @@ class AddonModel extends Gdn_Model {
                 'key' => implode('-', $parts)
             ];
         }
-        
+
         // If $end is no addon type, it must the version number.
         $version = $end;
         $end = array_pop($parts);
         if (in_array($end, self::$Types)) {
-            // Slug ends with type and version number.    
+            // Slug ends with type and version number.
             return [
                 'version' => $version,
                 'type' => $end,


### PR DESCRIPTION
This fixes issue #142 

It adds a new helper method to the AddonModel and replaces the places where addon keys are parsed errorneous with that helper method.

