### PR TITLE
Fix the call to addLink() when the menu is null

### DIFF
--- a/applications/addons/settings/class.hooks.php
+++ b/applications/addons/settings/class.hooks.php
@@ -19,7 +19,9 @@ class AddonsHooks implements Gdn_IPlugin {
      * @param Gdn_Controller $sender Sender object.
      */
     public function base_render_before(Gdn_Controller $sender) {
-        $sender->Menu->addLink('Addons', t('Addons'), '/addon/browse/all/recent', false, ['class' => 'Addons']);
+        if (is_object($sender->Menu)) {
+            $sender->Menu->addLink('Addons', t('Addons'), '/addon/browse/all/recent', false, ['class' => 'Addons']);
+        }
     }
 
     /**


### PR DESCRIPTION
The controller’s menu can be null if we are in an API context or a partial render context. Most hooks do an `is_object()` check or a plain truthy check.

closes https://github.com/vanilla/vanilla/issues/10427